### PR TITLE
Updated error response for create new blends (API)

### DIFF
--- a/core/api/tests/test_chemicals.py
+++ b/core/api/tests/test_chemicals.py
@@ -545,16 +545,16 @@ class TestCreateBlend:
             "composition": "A-20%; F-30%; SubstFFF-50%",
             "other_names": "Blend1 other names",
             "components": [
-                {"substance_id": substA.id, "component_name": "", "percentage": 20},
+                {"substance_id": substA.id, "component_name": "", "percentage": 19.2},
                 {
                     "substance_id": subst_otherF.id,
                     "component_name": "SubstFFF",
-                    "percentage": 50,
+                    "percentage": 50.3,
                 },
                 {
                     "substance_id": subst_otherF.id,
                     "component_name": "SubstFFF2",
-                    "percentage": 30,
+                    "percentage": 30.5,
                 },
             ],
         }
@@ -565,8 +565,10 @@ class TestCreateBlend:
         assert response.data["composition_alt"] == data["composition"]
         assert (
             response.data["composition"]
-            == "SubstFFF-50.00%; SubstFFF2-30.00%; SubstanceA-20.00%"
+            == "SubstFFF-50.30%; SubstFFF2-30.50%; SubstanceA-19.20%"
         )
-        assert float(response.data["odp"]) == substA.odp * 0.2 + subst_otherF.odp * 0.8
-        assert float(response.data["gwp"]) == subst_otherF.gwp * 0.8
+        assert (
+            float(response.data["odp"]) == substA.odp * 0.192 + subst_otherF.odp * 0.808
+        )
+        assert float(response.data["gwp"]) == subst_otherF.gwp * 0.808
         assert Blend.objects.count() == 1

--- a/core/api/views/chemicals.py
+++ b/core/api/views/chemicals.py
@@ -280,14 +280,14 @@ class BlendCreateView(generics.CreateAPIView):
             try:
                 subst = Substance.objects.select_related("group").get(id=subst_id)
             except Substance.DoesNotExist:
-                comp_errors[row_id] = {"substance_id": "Substance does not exist."}
+                comp_errors[row_id] = {"substance": "Substance does not exist."}
                 continue
 
             # check if component already exists in components dict
             if subst_id in existing_subst:
                 # if component already exists and is not "other" return error
                 comp_errors[row_id] = {
-                    "substance_id": "Substance already exists in the blend."
+                    "substance": "Substance already exists in the blend."
                 }
                 continue
 

--- a/core/api/views/chemicals.py
+++ b/core/api/views/chemicals.py
@@ -245,6 +245,7 @@ class BlendCreateView(generics.CreateAPIView):
                             "component_name": component_name (string),
                             "percentage": percentage (float),
                             "substance_id": substance_id (int),
+                            "rowId": used in error response (string),
                             }
                         ],
                     "odp": odp (decimal),
@@ -257,55 +258,43 @@ class BlendCreateView(generics.CreateAPIView):
         gwp = 0
         percentage_sum = 0
         existing_subst = set()
+        comp_errors = {}
 
         for index, vals in enumerate(blend_components):
-            try:
-                assert isinstance(vals, dict), "Component must be a dictionary"
-                subst_id = vals["substance_id"]
-                component_name = vals["component_name"]
-                percentage = vals["percentage"]
-            except (ValueError, AssertionError) as e:
+            if not isinstance(vals, dict):
                 raise ValidationError(
-                    {"components": {index: f"Incorrect component: {e}"}}
-                ) from e
+                    {"components": "There is a component that is not a dict"}
+                )
+
+            row_id = vals.pop("rowId", index)
             try:
-                prcnt_decimal = Decimal(percentage / 100)
-            except (ValueError, ArithmeticError, TypeError) as e:
-                raise ValidationError(
-                    {"components": {index: f"Invalid percentage: {percentage}"}}
-                ) from e
+                subst_id = vals.get("substance_id", None)
+                component_name = vals.get("component_name", None)
+                percentage = Decimal(str(vals["percentage"]))
+                prcnt_decimal = percentage / 100
+            except (ArithmeticError, TypeError, ValueError):
+                comp_errors[row_id] = {"percentage": "Invalid value"}
+                continue
+
             # get substance by id, if it does not exist return error
             try:
                 subst = Substance.objects.select_related("group").get(id=subst_id)
-            except Substance.DoesNotExist as e:
-                raise ValidationError(
-                    {
-                        "components": {
-                            index: f"Substance with id {subst_id} does not exist"
-                        }
-                    }
-                ) from e
+            except Substance.DoesNotExist:
+                comp_errors[row_id] = {"substance_id": "Substance does not exist."}
+                continue
 
             # check if component already exists in components dict
             if subst_id in existing_subst:
                 # if component already exists and is not "other" return error
-                raise ValidationError(
-                    {
-                        "components": {
-                            index: f"Substance with id {subst_id} already exists"
-                        }
-                    }
-                )
+                comp_errors[row_id] = {
+                    "substance_id": "Substance already exists in the blend."
+                }
+                continue
 
             if "other" in subst.name.lower() and not component_name:
                 # components of "other" substances must have a specific name
-                raise ValidationError(
-                    {
-                        "components": {
-                            index: f"Please add a specific name for the component with id {subst_id}",
-                        }
-                    }
-                )
+                comp_errors[row_id] = {"component_name": "Please add a component name"}
+                continue
 
             # add component to the component list
             components.append(
@@ -330,6 +319,10 @@ class BlendCreateView(generics.CreateAPIView):
 
             # set percentage_sum
             percentage_sum += percentage
+
+        # check if there are any errors
+        if comp_errors:
+            raise ValidationError({"components": comp_errors})
 
         # check if percentage_sum is 100
         if percentage_sum != 100:


### PR DESCRIPTION
- [x]  Update error response (create new blends)
    - [x] Use rowId as a key in errors dict
    - [x] Use substance instead of substance_id as a field name
    - [x] If the error is for the entire component then the error will be a string not a dictionary 