### PR TITLE
Updated cp report filters and serialiser

### DIFF
--- a/core/api/filters/country_programme.py
+++ b/core/api/filters/country_programme.py
@@ -33,12 +33,21 @@ class CPReportArchiveFilter(CPReportFilter):
     country_programme_report_id = filters.NumberFilter(
         method="filter_by_country_programme_report_id"
     )
+    cp_report_archive_id = filters.NumberFilter(method="filter_by_cp_report_archive_id")
 
     def filter_by_country_programme_report_id(self, queryset, _, value):
         cp_report = CPReport.objects.filter(id=value).first()
         if not cp_report:
             return queryset.none()
         return queryset.filter(country_id=cp_report.country_id, year=cp_report.year)
+
+    def filter_by_cp_report_archive_id(self, queryset, _, value):
+        cp_report_archive = CPReportArchive.objects.filter(id=value).first()
+        if not cp_report_archive:
+            return queryset.none()
+        return queryset.filter(
+            country_id=cp_report_archive.country_id, year=cp_report_archive.year
+        )
 
     class Meta:
         model = CPReportArchive

--- a/core/api/serializers/base.py
+++ b/core/api/serializers/base.py
@@ -60,10 +60,12 @@ class BaseCPWChemicalSerializer(BaseCPRowSerializer):
     chemical_name = serializers.SerializerMethodField()
     substance_id = serializers.PrimaryKeyRelatedField(
         required=False,
+        allow_null=True,
         queryset=Substance.objects.all().values_list("id", flat=True),
     )
     blend_id = serializers.PrimaryKeyRelatedField(
         required=False,
+        allow_null=True,
         queryset=Blend.objects.all().values_list("id", flat=True),
     )
     country_programme_report_id = serializers.PrimaryKeyRelatedField(

--- a/core/api/serializers/cp_report.py
+++ b/core/api/serializers/cp_report.py
@@ -44,9 +44,18 @@ class CPReportSerializer(CPReportBaseSerializer):
 
 
 class CPReportArchiveSerializer(CPReportBaseSerializer):
+    final_version_id = serializers.SerializerMethodField()
+
     class Meta(CPReportBaseSerializer.Meta):
         model = CPReportArchive
-        fields = CPReportBaseSerializer.Meta.fields + ["created_at"]
+        fields = CPReportBaseSerializer.Meta.fields + ["created_at", "final_version_id"]
+
+    def get_final_version_id(self, obj):
+        cp_report_final = CPReport.objects.filter(
+            country_id=obj.country_id,
+            year=obj.year,
+        ).first()
+        return cp_report_final.id if cp_report_final else None
 
 
 class CPReportGroupSerializer(serializers.Serializer):

--- a/core/api/tests/test_cp_report.py
+++ b/core/api/tests/test_cp_report.py
@@ -240,11 +240,13 @@ def setup_section_a_c(substance, blend, usage):
     section_a = [
         {
             "substance_id": substance.id,
+            "blend_id": None,
             "rowId": f"substance_{substance.id}",
             **cp_record_data,
         },
         {
             "substance_id": substance2.id,
+            "blend_id": None,
             "rowId": f"substance_{substance2.id}",
             **cp_record_data,
         },
@@ -252,12 +254,14 @@ def setup_section_a_c(substance, blend, usage):
     section_c = [
         {
             "substance_id": substance.id,
+            "blend_id": None,
             "rowId": f"substance_{substance.id}",
             "current_year_price": 25.5,
             "remarks": "Mama mea cand mi-a dat viata",
         },
         {
             "blend_id": blend.id,
+            "substance_id": None,
             "rowId": f"blend_{blend.id}",
             "previous_year_price": 12.4,
             "current_year_price": 25.5,

--- a/core/api/views/cp_records.py
+++ b/core/api/views/cp_records.py
@@ -253,9 +253,13 @@ class CPRecordBaseListView(mixins.ListModelMixin, generics.GenericAPIView):
 
     def _get_cp_report(self):
         try:
-            return self.cp_report_class.objects.get(id=self.request.query_params["cp_report_id"])
+            return self.cp_report_class.objects.get(
+                id=self.request.query_params["cp_report_id"]
+            )
         except KeyError as e:
-            raise ValidationError({"cp_report_id": "query parameter is required"}) from e
+            raise ValidationError(
+                {"cp_report_id": "query parameter is required"}
+            ) from e
         except CPReport.DoesNotExist as e:
             raise ValidationError({"cp_report_id": "invalid id"}) from e
 


### PR DESCRIPTION
- add cp_report_archive_id filter for cp record version list
- add final_version_id field in cp_report serialiser
- fixed create/update cp_report with null values for chemicals