### PR TITLE
Allow editing of 1995-2004 reports

### DIFF
--- a/core/api/views/cp_records.py
+++ b/core/api/views/cp_records.py
@@ -342,7 +342,7 @@ class CPRecordBaseListView(views.APIView):
         return cp_report
 
     def get_data(self, cp_report):
-        if cp_report.year < IMPORT_DB_OLDEST_MAX_YEAR:
+        if cp_report.year <= IMPORT_DB_OLDEST_MAX_YEAR:
             return self._get_04_cp_records(cp_report)
         if cp_report.year > IMPORT_DB_MAX_YEAR:
             return self._get_new_cp_records(cp_report)

--- a/frontend/src/components/manage/Blocks/CountryProgramme/CPEdit.tsx
+++ b/frontend/src/components/manage/Blocks/CountryProgramme/CPEdit.tsx
@@ -124,27 +124,27 @@ function CPEdit() {
   const Sections = {
     section_a: useMakeClassInstance<SectionA>(SectionA, [
       report.data?.section_a,
-      report.emptyForm.data.substance_rows.section_a?.filter(
+      report.emptyForm.data?.substance_rows?.section_a?.filter(
         (item) => item.substance_id,
       ) || [],
       null,
     ]),
     section_b: useMakeClassInstance<SectionB>(SectionB, [
       report.data?.section_b,
-      report.emptyForm.data.substance_rows.section_b?.filter(
+      report.emptyForm.data?.substance_rows?.section_b?.filter(
         (item) => item.substance_id,
       ) || [],
-      report.emptyForm.data.substance_rows.section_b?.filter(
+      report.emptyForm.data?.substance_rows?.section_b?.filter(
         (item) => item.blend_id,
       ),
       null,
     ]),
     section_c: useMakeClassInstance<SectionC>(SectionC, [
       report.data?.section_c,
-      report.emptyForm.data.substance_rows.section_c?.filter(
+      report.emptyForm.data?.substance_rows?.section_c?.filter(
         (item) => item.substance_id,
       ) || [],
-      report.emptyForm.data.substance_rows.section_c?.filter(
+      report.emptyForm.data?.substance_rows?.section_c?.filter(
         (item) => item.blend_id,
       ) || [],
       null,


### PR DESCRIPTION
- refs https://helpdesk.eaudeweb.ro/issues/24174

- [x] Added some optional chaining to minimize client errors
- [x] Added 2004 in the list of old reports