### PR TITLE
Fix section overlay opacity; Tailwind needs complete class names

### DIFF
--- a/frontend/src/components/manage/Blocks/CountryProgramme/CPComments.tsx
+++ b/frontend/src/components/manage/Blocks/CountryProgramme/CPComments.tsx
@@ -96,7 +96,7 @@ const CPComments: React.FC = () => {
             className="relative flex min-w-96 flex-1 flex-col rounded-lg bg-gray-100 p-2"
           >
             {user_type !== allowComments[label] && (
-              <SectionOverlay className="cursor-not-allowed" opacity={60} />
+              <SectionOverlay className="cursor-not-allowed" opacity="opacity-60" />
             )}
             <label className="py-2 text-2xl font-normal">
               {label.toLocaleUpperCase()}

--- a/frontend/src/components/ui/SectionOverlay/SectionOverlay.tsx
+++ b/frontend/src/components/ui/SectionOverlay/SectionOverlay.tsx
@@ -1,7 +1,7 @@
-const SectionOverlay = ({ className = "", opacity = 70 }) => {
+const SectionOverlay = ({ className = "", opacity = 'opacity-70' }) => {
   return (
     <div
-      className={`absolute inset-0 z-50 bg-gray-100 opacity-${opacity} ${className}`}
+      className={`absolute inset-0 z-50 bg-gray-100 ${opacity} ${className}`}
     ></div>
   )
 }


### PR DESCRIPTION
- refs https://helpdesk.eaudeweb.ro/issues/24183

Tailwind needs to "read" complete class names. `className={`opacity-${value}`} won't work.