### PR TITLE
Include `substance_rows` in 1995-2004 reports so mandatory rows can deduced

### DIFF
--- a/core/api/views/cp_report_empty_form.py
+++ b/core/api/views/cp_report_empty_form.py
@@ -247,6 +247,7 @@ class EmptyFormView(views.APIView):
     def get_04_empty_form(cls, year):
         return {
             "usage_columns": cls.get_usage_columns(year),
+            "substance_rows": cls.get_substance_rows(year),
         }
 
     @classmethod


### PR DESCRIPTION
I'm not sure of the implications of adding this here, so please test it.