### PR TITLE
Udpated flow for updating report status

### DIFF
--- a/core/api/serializers/cp_report.py
+++ b/core/api/serializers/cp_report.py
@@ -244,7 +244,7 @@ class CPReportCreateSerializer(serializers.Serializer):
         cp_report_data = {
             "name": validated_data.get("name"),
             "year": validated_data.get("year"),
-            "status": validated_data.get("status", CPReport.CPReportStatus.FINAL),
+            "status": validated_data.get("status", CPReport.CPReportStatus.DRAFT),
             "country_id": validated_data.get("country_id"),
         }
 


### PR DESCRIPTION
[#24568](https://helpdesk.eaudeweb.ro/issues/24568)

- [x] Create new history record if the status is updated with PUT /cp_report/
- [x] Set default status to Draft (at create new report from api)