### PR TITLE
CEIT countries import and data

### DIFF
--- a/core/api/tests/factories.py
+++ b/core/api/tests/factories.py
@@ -21,7 +21,7 @@ from core.models.business_plan import (
 from core.models.adm import AdmChoice, AdmColumn, AdmRecord, AdmRow
 from core.models.agency import Agency
 from core.models.base import CommentType
-from core.models.country import Country
+from core.models.country import Country, CountryCEITStatus
 from core.models.country_programme import (
     CPEmission,
     CPGeneration,
@@ -523,6 +523,16 @@ class ScaleOfAssessmentFactory(factory.django.DjangoModelFactory):
     )
     average_inflation_rate = factory.Faker("pydecimal", left_digits=10, right_digits=2)
     override_qualifies_for_fixed_rate_mechanism = factory.Faker("pybool")
+
+
+class CountryCEITStatusFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = CountryCEITStatus
+
+    country = factory.SubFactory(CountryFactory)
+    start_year = factory.Faker("random_int", min=2000, max=2024)
+    end_year = factory.Faker("random_int", min=2000, max=2024)
+    is_ceit = factory.Faker("pybool")
 
 
 class AnnualContributionStatusFactory(factory.django.DjangoModelFactory):

--- a/core/api/tests/test_replenishment.py
+++ b/core/api/tests/test_replenishment.py
@@ -20,6 +20,7 @@ from core.api.tests.factories import (
     PaymentFactory,
     TriennialContributionStatusFactory,
     ScaleOfAssessmentVersionFactory,
+    CountryCEITStatusFactory,
 )
 from core.models import (
     ExternalIncome,
@@ -276,6 +277,14 @@ class TestStatusOfContributions:
                     ).quantize(self.fifteen_decimals),
                 },
             ],
+            "ceit": {
+                "agreed_contributions": 0,
+                "cash_payments": 0,
+                "bilateral_assistance": 0,
+                "promissory_notes": 0,
+                "outstanding_contributions": 0,
+            },
+            "ceit_countries": [],
             "total": {
                 "agreed_contributions": (
                     contribution_1.agreed_contributions
@@ -424,6 +433,14 @@ class TestStatusOfContributions:
                     ),
                 },
             ],
+            "ceit": {
+                "agreed_contributions": 0,
+                "cash_payments": 0,
+                "bilateral_assistance": 0,
+                "promissory_notes": 0,
+                "outstanding_contributions": 0,
+            },
+            "ceit_countries": [],
             "total": {
                 "agreed_contributions": (
                     contribution_1.agreed_contributions
@@ -461,10 +478,17 @@ class TestStatusOfContributions:
     def test_summary_status_of_contributions(self, user):
         country_1 = CountryFactory.create(name="Country 1", iso3="XYZ")
         country_2 = CountryFactory.create(name="Country 2", iso3="ABC")
+
         year_1 = 2020
         year_2 = 2022
         year_3 = 2023
         year_4 = 2025
+        CountryCEITStatusFactory.create(
+            country=country_1, start_year=year_1, end_year=year_2, is_ceit=True
+        )
+        CountryCEITStatusFactory.create(
+            country=country_2, start_year=year_3, end_year=None, is_ceit=True
+        )
 
         contribution_1 = TriennialContributionStatusFactory.create(
             country=country_1, start_year=year_1, end_year=year_2
@@ -567,6 +591,46 @@ class TestStatusOfContributions:
                     "gain_loss": ferm_gain_loss_2.amount.quantize(
                         self.fifteen_decimals
                     ),
+                },
+            ],
+            "ceit": {
+                "agreed_contributions": (
+                    contribution_1.agreed_contributions
+                    + contribution_4.agreed_contributions
+                ).quantize(self.fifteen_decimals),
+                "cash_payments": (
+                    contribution_1.cash_payments + contribution_4.cash_payments
+                ).quantize(self.fifteen_decimals),
+                "bilateral_assistance": (
+                    contribution_1.bilateral_assistance
+                    + contribution_4.bilateral_assistance
+                ).quantize(self.fifteen_decimals),
+                "promissory_notes": (
+                    contribution_1.promissory_notes + contribution_4.promissory_notes
+                ).quantize(self.fifteen_decimals),
+                "outstanding_contributions": (
+                    contribution_1.outstanding_contributions
+                    + contribution_4.outstanding_contributions
+                ).quantize(self.fifteen_decimals),
+            },
+            "ceit_countries": [
+                {
+                    "id": country_1.id,
+                    "name": country_1.name,
+                    "abbr": country_1.abbr,
+                    "name_alt": country_1.name_alt,
+                    "iso3": country_1.iso3,
+                    "has_cp_report": None,
+                    "is_a2": country_1.is_a2,
+                },
+                {
+                    "id": country_2.id,
+                    "name": country_2.name,
+                    "abbr": country_2.abbr,
+                    "name_alt": country_2.name_alt,
+                    "iso3": country_2.iso3,
+                    "has_cp_report": None,
+                    "is_a2": country_2.is_a2,
                 },
             ],
             "total": {

--- a/core/api/views/replenishment.py
+++ b/core/api/views/replenishment.py
@@ -6,10 +6,10 @@ import urllib
 from decimal import Decimal
 
 import openpyxl
-from django.db.models import Q, F
-from django_filters.rest_framework import DjangoFilterBackend
 from django.db import models, transaction
+from django.db.models import Q, F
 from django.http import HttpResponse
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters, generics, mixins, status, views, viewsets
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
@@ -48,7 +48,6 @@ from core.models import (
     ScaleOfAssessment,
     ScaleOfAssessmentVersion,
     TriennialContributionStatus,
-    CountryCEITStatus,
 )
 
 

--- a/core/import_data/import_status_of_contributions.py
+++ b/core/import_data/import_status_of_contributions.py
@@ -15,6 +15,7 @@ from core.models import (
     TriennialContributionStatus,
     ExternalIncome,
     ExternalAllocation,
+    CountryCEITStatus,
 )
 
 
@@ -382,6 +383,113 @@ def decimal_converter(value):
         return 0
 
 
+CEIT = [
+    {
+        "country": "Azerbaijan",
+        "start_year": 1991,
+        "end_year": None,
+        "is_ceit": True,
+    },
+    {
+        "country": "Belarus",
+        "start_year": 1991,
+        "end_year": None,
+        "is_ceit": True,
+    },
+    {
+        "country": "Bulgaria",
+        "start_year": 1991,
+        "end_year": None,
+        "is_ceit": True,
+    },
+    {
+        "country": "Czechia",
+        "start_year": 1991,
+        "end_year": None,
+        "is_ceit": True,
+    },
+    {
+        "country": "Estonia",
+        "start_year": 1991,
+        "end_year": None,
+        "is_ceit": True,
+    },
+    {
+        "country": "Hungary",
+        "start_year": 1991,
+        "end_year": None,
+        "is_ceit": True,
+    },
+    {
+        "country": "Kazakhstan",
+        "start_year": 2015,
+        "end_year": None,
+        "is_ceit": True,
+    },
+    {
+        "country": "Latvia",
+        "start_year": 1991,
+        "end_year": None,
+        "is_ceit": True,
+    },
+    {
+        "country": "Lithuania",
+        "start_year": 1991,
+        "end_year": None,
+        "is_ceit": True,
+    },
+    {
+        "country": "Poland",
+        "start_year": 1991,
+        "end_year": None,
+        "is_ceit": True,
+    },
+    {
+        "country": "Russian Federation",
+        "start_year": 1991,
+        "end_year": None,
+        "is_ceit": True,
+    },
+    {
+        "country": "Slovakia",
+        "start_year": 1991,
+        "end_year": None,
+        "is_ceit": True,
+    },
+    {
+        "country": "Slovenia",
+        "start_year": 1991,
+        "end_year": None,
+        "is_ceit": True,
+    },
+    {
+        "country": "Tajikistan",
+        "start_year": 1991,
+        "end_year": None,
+        "is_ceit": True,
+    },
+    {
+        "country": "Turkmenistan",
+        "start_year": 1991,
+        # It's actually 2004, but it's counted for the whole 2003-2005 triennial
+        "end_year": 2005,
+        "is_ceit": True,
+    },
+    {
+        "country": "Ukraine",
+        "start_year": 1991,
+        "end_year": None,
+        "is_ceit": True,
+    },
+    {
+        "country": "Uzbekistan",
+        "start_year": 1991,
+        "end_year": None,
+        "is_ceit": True,
+    },
+]
+
+
 @transaction.atomic
 def import_status_of_contributions(countries):
     """
@@ -394,6 +502,23 @@ def import_status_of_contributions(countries):
     delete_old_data(FermGainLoss)
     delete_old_data(ExternalIncome)
     delete_old_data(ExternalAllocation)
+    delete_old_data(CountryCEITStatus)
+
+    # Import CEIT status
+
+    ceit_objects = []
+    for ceit in CEIT:
+        country = countries[ceit["country"]]
+        ceit_objects.append(
+            CountryCEITStatus(
+                country=country,
+                start_year=ceit["start_year"],
+                end_year=ceit["end_year"],
+                is_ceit=ceit["is_ceit"],
+            )
+        )
+    CountryCEITStatus.objects.bulk_create(ceit_objects)
+    logger.info(f"Imported ({len(ceit_objects)}) CEIT statuses")
 
     soc_file = pd.ExcelFile(IMPORT_RESOURCES_DIR / "9403_Annex_I_270524.xlsx")
 

--- a/core/import_data/import_status_of_contributions.py
+++ b/core/import_data/import_status_of_contributions.py
@@ -1,5 +1,5 @@
 # TODO: split into more functions
-# pylint: disable=R0915
+# pylint: disable=R0915,R0914
 
 import decimal
 import logging

--- a/core/models/country.py
+++ b/core/models/country.py
@@ -58,7 +58,7 @@ class Country(models.Model):
         """
         for ceit_status in self.ceit_statuses.all():
             if year >= ceit_status.start_year and (
-                ceit_status.end_year is None or year <= ceit_status
+                ceit_status.end_year is None or year <= ceit_status.end_year
             ):
                 return ceit_status.is_ceit
 

--- a/frontend/src/components/manage/Blocks/Replenishment/StatusOfContribution/useGetSCData.js
+++ b/frontend/src/components/manage/Blocks/Replenishment/StatusOfContribution/useGetSCData.js
@@ -7,6 +7,7 @@ const BASE_URL = '/api/replenishment/status-of-contributions'
 
 function useGetSCData(start_year, end_year) {
   const [data, setData] = useState({
+    ceit: null,
     disputed_contributions: null,
     disputed_contributions_per_country: null,
     status_of_contributions: null,
@@ -41,6 +42,7 @@ function useGetSCData(start_year, end_year) {
         setRows(transformData(data.status_of_contributions))
 
         setData({
+          ceit: data.ceit,
           disputed_contributions: data.disputed_contributions,
           disputed_contributions_per_country:
             data.disputed_contributions_per_country,
@@ -87,6 +89,14 @@ function useGetSCData(start_year, end_year) {
           country: 'Total',
           outstanding_contributions:
             data.total?.outstanding_contributions_with_disputed,
+        },
+        {
+          agreed_contributions: data.ceit?.agreed_contributions,
+          bilateral_assistance: data.ceit?.bilateral_assistance,
+          cash_payments: data.ceit?.cash_payments,
+          country: 'CEIT',
+          outstanding_contributions: data.ceit?.outstanding_contributions,
+          promissory_notes: data.ceit?.promissory_notes,
         },
       ]
     },

--- a/frontend/src/components/manage/Blocks/Replenishment/StatusOfContribution/utils.js
+++ b/frontend/src/components/manage/Blocks/Replenishment/StatusOfContribution/utils.js
@@ -6,7 +6,7 @@ export const SC_COLUMNS = [
   { field: 'country', label: 'Country' },
   { field: 'agreed_contributions', label: 'Agreed Contributions' },
   { field: 'cash_payments', label: 'Cash Payments' },
-  { field: 'bilateral_assisstance', label: 'Bilateral Assistance' },
+  { field: 'bilateral_assistance', label: 'Bilateral Assistance' },
   { field: 'promissory_notes', label: 'Promissory Notes' },
   { field: 'outstanding_contributions', label: 'Outstanding Contribution' },
 ]
@@ -50,7 +50,7 @@ export function transformData(data) {
   for (let i = 0; i < data.length; i++) {
     rows.push({
       agreed_contributions: data[i].agreed_contributions,
-      bilateral_assisstance: data[i].bilateral_assisstance,
+      bilateral_assistance: data[i].bilateral_assistance,
       cash_payments: data[i].cash_payments,
       country: data[i].country.name_alt,
       country_id: data[i].country.id,


### PR DESCRIPTION
Re-import steps:
- delete all invoices/payments
- run `./manage.py import_replenishments all`

@GeorgeFlorian CEIT countries and data are available in each SoC endpoint under the keys `ceit` and `ceit_countries`