### PR TITLE
Updated number format from the export files cells (CP)

### DIFF
--- a/core/api/export/base.py
+++ b/core/api/export/base.py
@@ -160,6 +160,9 @@ class BaseWriter:
             top=Side(style="hair"),
             bottom=Side(style="hair"),
         )
+        if align == "right":
+            # this cell will contain a number
+            cell.number_format = "###,###,##0.00#############"
         if read_only:
             cell.fill = PatternFill(
                 start_color="EEEEEE", end_color="EEEEEE", fill_type="solid"

--- a/core/api/export/cp_data_extraction_all.py
+++ b/core/api/export/cp_data_extraction_all.py
@@ -535,16 +535,19 @@ class MbrConsumptionWriter(BaseWriter):
             {
                 "id": "methyl_bromide_qps",
                 "headerName": "Methyl Bromide - QPS",
+                "align": "right",
                 "type": "number",
             },
             {
                 "id": "methyl_bromide_non_qps",
                 "headerName": "Methyl Bromide — Non-QPS",
+                "align": "right",
                 "type": "number",
             },
             {
                 "id": "total",
                 "headerName": "Total",
+                "align": "right",
                 "type": "number",
             },
         ]

--- a/core/api/export/cp_report_hfc_hcfc.py
+++ b/core/api/export/cp_report_hfc_hcfc.py
@@ -28,24 +28,28 @@ class CPReportHCFCWriter(CPDataHFCHCFCWriterBase):
                 "headerName": "Total",
                 "is_sum_function": True,
                 "convert_to_odp": True,
+                "align": "right",
             },
             {
                 "id": "imports",
                 "headerName": "Import",
                 "type": "number",
                 "convert_to_odp": True,
+                "align": "right",
             },
             {
                 "id": "exports",
                 "headerName": "Export",
                 "type": "number",
                 "convert_to_odp": True,
+                "align": "right",
             },
             {
                 "id": "production",
                 "headerName": "Production",
                 "type": "number",
                 "convert_to_odp": True,
+                "align": "right",
             },
             {
                 "id": "remarks",

--- a/core/api/export/cp_report_new.py
+++ b/core/api/export/cp_report_new.py
@@ -71,19 +71,16 @@ class CPReportNewExporter(CPReportBase):
                     {
                         "id": "imports",
                         "headerName": "Import",
-                        "convertable": True,
                         "align": "right",
                     },
                     {
                         "id": "exports",
                         "headerName": "Export",
-                        "convertable": True,
                         "align": "right",
                     },
                     {
                         "id": "production",
                         "headerName": "Production",
-                        "convertable": True,
                         "align": "right",
                     },
                     *(
@@ -99,12 +96,12 @@ class CPReportNewExporter(CPReportBase):
                     {
                         "id": "import_quotas",
                         "headerName": "Import Quotas",
-                        "convertable": True,
                         "align": "right",
                     },
                     {
                         "id": "banned_date",
                         "headerName": "Date ban commenced",
+                        "type": "date",
                         "is_numeric": False,
                     },
                     {
@@ -116,10 +113,6 @@ class CPReportNewExporter(CPReportBase):
                 ],
             }
         ]
-        if convert_to != "mt":
-            for header in headers[0]["children"]:
-                if header.get("convertable"):
-                    header["headerName"] += f"_{convert_to}"
         SectionWriter(sheet, headers, convert_to).write(data)
 
     def export_section_c(self, sheet, data, *args):
@@ -293,5 +286,7 @@ class CPReportNewExporter(CPReportBase):
 
         cell = sheet.cell(row_idx, col_idx, value)
         cell.alignment = Alignment(horizontal="left", vertical="top", wrap_text=True)
-        sheet.column_dimensions[get_column_letter(col_idx)].width = self.COLUMN_WIDTH * 4
+        sheet.column_dimensions[get_column_letter(col_idx)].width = (
+            self.COLUMN_WIDTH * 4
+        )
         sheet.row_dimensions[row_idx].height = self.ROW_HEIGHT * 16

--- a/core/api/export/section_export.py
+++ b/core/api/export/section_export.py
@@ -1,4 +1,5 @@
 from openpyxl.utils import get_column_letter
+from dateutil.parser import parse
 
 from core.api.export.base import BaseWriter
 
@@ -99,6 +100,9 @@ class SectionWriter(BaseWriter):
                 read_only = True
             elif header.get("is_numeric", True):
                 value = float(value or 0)
+            elif header.get("type", None) == "date":
+                # DD/MM/YYYY
+                value = parse(value).strftime("%d/%m/%Y") if value else ""
             else:
                 value = value or ""
 

--- a/core/api/views/cp_records_export.py
+++ b/core/api/views/cp_records_export.py
@@ -57,6 +57,13 @@ from core.models.country_programme_archive import (
 from core.utils import IMPORT_DB_MAX_YEAR
 
 
+EXCLUDE_FROM_CONSUMPTION = [
+    "CII",
+    "Other",
+    "Legacy",
+]
+
+
 class CPRecordExportView(CPRecordListView):
     def get_usages(self, cp_report):
         empty_form = EmptyFormView.get_data(cp_report.year, cp_report)
@@ -238,7 +245,7 @@ class CPCalculatedAmountExportView(CPRecordListView):
         data = {
             group: {"sectorial_total": 0, "consumption": 0}
             for group in SUBSTANCE_GROUP_ID_TO_CATEGORY.values()
-            if group not in ["Other", "Legacy"]
+            if group not in EXCLUDE_FROM_CONSUMPTION
         }
 
         # calculate the consumption and sectorial total
@@ -254,7 +261,7 @@ class CPCalculatedAmountExportView(CPRecordListView):
             else:
                 substance_category = "HFC"
 
-            if substance_category in ["Other", "Legacy"]:
+            if substance_category in EXCLUDE_FROM_CONSUMPTION:
                 continue
 
             # get the sectorial total
@@ -370,6 +377,7 @@ class CPHCFCExportView(CPHFCHCFCExportBaseView):
                     ),
                     "columnCategory": "usage",
                     "convert_to_odp": True,
+                    "align": "right",
                 }
             )
 
@@ -417,6 +425,7 @@ class CPHFCExportView(CPHFCHCFCExportBaseView):
                         "headerName": f"{us_format.usage.full_name} {q_type}",
                         "columnCategory": "usage",
                         "quantity_type": q_type,
+                        "align": "right",
                     }
                 )
 


### PR DESCRIPTION
[25988](https://helpdesk.eaudeweb.ro/issues/25988)

- [x] 3. Format the numbers in Excel export (and PDF)
- [x] 22. The data in the “Calculated amounts” and “Download” function for Excel and PDF file should be formatted accordingly. For ODP and metric tonnes with 1,222.50 and CO2-eq should be 1,222,456. In addition, HBFC should be removed from the table both in the PDF and Excel file.
- [x] 23. The headers in the “Download” function for Excel and PDF file should be changed as follows. Since the unit is already included at the top of the tables, there is no need to mention ODP or GWP in the headers for Import, Export, Production and Import Quotas. In addition, the date format in the Exel or PDF file should be DD/MM/YYYY.
- [x] 24. Total column is not exported in CP Data Extraction – HCFC.