### PR TITLE
Display full year range in business plans table

### DIFF
--- a/frontend/src/components/manage/Blocks/Table/BusinessPlansTable/BusinessPlansTable.tsx
+++ b/frontend/src/components/manage/Blocks/Table/BusinessPlansTable/BusinessPlansTable.tsx
@@ -67,18 +67,13 @@ export default function BusinessPlansTable() {
       year <= yearRangeSelected.max_year;
       year++
     ) {
-      let label = year
-      if (year === yearRangeSelected.max_year) {
-        label = `After ${year - 1}`
-      }
-
       valuesUSD.push({
         autoHeaderHeight: true,
         autoHeight: true,
         cellClass: 'ag-text-center',
         field: `value_usd_${year}`,
         headerClass: 'ag-text-center',
-        headerName: `${label}`,
+        headerName: `${year}`,
         minWidth: 80,
         resizable: true,
         valueGetter: (params: any) => {
@@ -96,7 +91,7 @@ export default function BusinessPlansTable() {
         cellClass: 'ag-text-center',
         field: `value_odp_${year}`,
         headerClass: 'ag-text-center',
-        headerName: `${label}`,
+        headerName: `${year}`,
         minWidth: 80,
         resizable: true,
         valueGetter: (params: any) => {
@@ -114,7 +109,7 @@ export default function BusinessPlansTable() {
         cellClass: 'ag-text-center',
         field: `value_mt_${year}`,
         headerClass: 'ag-text-center',
-        headerName: `${label}`,
+        headerName: `${year}`,
         minWidth: 80,
         resizable: true,
         valueGetter: (params: any) => {
@@ -181,7 +176,7 @@ export default function BusinessPlansTable() {
           rowData={results}
           tooltipShowDelay={200}
           Toolbar={() => (
-            <div className="flex items-center justify-between gap-1 mb-4">
+            <div className="mb-4 flex items-center justify-between gap-1">
               <ActivitiesFilters
                 bpSlice={bpSlice}
                 clusters={clusters}


### PR DESCRIPTION
Refs https://helpdesk.eaudeweb.ro/issues/25078

- In business plans table, for columns "Value", "ODP" and "MT for HFC", the title of the last year column is now the corresponding year instead of "After ..."