### PR TITLE
Fixing clipped sub-sub-sub usage header

### DIFF
--- a/core/api/export/base.py
+++ b/core/api/export/base.py
@@ -155,6 +155,10 @@ class BaseWriter:
         )
         if comment:
             cell.comment = Comment(comment, "")
+        # Hack to avoid clipped header in exported PDF.
+        # TODO: find a way (?) to improve this in the future.
+        if value == "Other unidentified manufacturing":
+            self.sheet.row_dimensions[row].height = self.ROW_HEIGHT * 4 / 3
         return cell
 
     def _write_record_cell(


### PR DESCRIPTION
The "Other unidentified manufacturing" usage header in Section B is vertically clipped at PDF export. This is because the `libreoffice` exporter in staging/prod cannot load the default Arial font and uses a wider one instead.

So we are just adjusting the height of that row for the text to fit properly.

This is a horrible solution, but cannot find a better way to fix it without refactoring the entire export logic.