### PR TITLE
Adding more invoice filters

### DIFF
--- a/core/api/filters/replenishment.py
+++ b/core/api/filters/replenishment.py
@@ -28,7 +28,7 @@ class InvoiceFilter(filters.FilterSet):
     year = filters.NumberFilter(field_name="year")
     status = filters.CharFilter(method="filter_status")
 
-    reminders_sent = filter.NumberFilter(method="filter_reminders_sent")
+    reminders_sent = filters.NumberFilter(method="filter_reminders_sent")
 
     def filter_status(self, queryset, _name, value):
         if value == "pending":

--- a/core/api/filters/replenishment.py
+++ b/core/api/filters/replenishment.py
@@ -40,6 +40,7 @@ class InvoiceFilter(filters.FilterSet):
         return queryset
 
     def filter_reminders_sent(self, queryset, _name, value):
+        # pylint: disable-next=R1705
         if value == 0:
             return queryset.filter(
                 date_first_reminder__isnull=True, date_second_reminder__isnull=True

--- a/core/api/filters/replenishment.py
+++ b/core/api/filters/replenishment.py
@@ -1,5 +1,6 @@
 from django_filters import rest_framework as filters
 from django_filters.widgets import CSVWidget
+from django.db.models import Exists, OuterRef, Subquery
 
 from core.models import Country, Invoice, Payment, ScaleOfAssessment
 
@@ -29,6 +30,7 @@ class InvoiceFilter(filters.FilterSet):
     status = filters.CharFilter(method="filter_status")
 
     reminders_sent = filters.NumberFilter(method="filter_reminders_sent")
+    opted_for_ferm = filters.BooleanFilter(method="filter_opted_for_ferm")
 
     def filter_status(self, queryset, _name, value):
         if value == "pending":
@@ -52,6 +54,20 @@ class InvoiceFilter(filters.FilterSet):
             )
         else:
             return queryset
+
+    def filter_opted_for_ferm(self, queryset, _name, value):
+        # `queryset` is of Invoice
+        ret = queryset.annotate(
+            opted_for_ferm=Subquery(
+                ScaleOfAssessment.objects.filter(
+                    country=OuterRef("country"),
+                    version__replenishment__start_year__lte=OuterRef("year"),
+                    version__replenishment__end_year__gte=OuterRef("year"),
+                ).values("opted_for_ferm")[:1]
+            )
+        ).filter(opted_for_ferm=value)
+
+        return ret
 
     class Meta:
         model = Invoice

--- a/core/api/filters/replenishment.py
+++ b/core/api/filters/replenishment.py
@@ -28,6 +28,8 @@ class InvoiceFilter(filters.FilterSet):
     year = filters.NumberFilter(field_name="year")
     status = filters.CharFilter(method="filter_status")
 
+    reminders_sent = filter.NumberFilter(method="filter_reminders_sent")
+
     def filter_status(self, queryset, _name, value):
         if value == "pending":
             return queryset.filter(date_paid__isnull=True)
@@ -35,9 +37,25 @@ class InvoiceFilter(filters.FilterSet):
             return queryset.filter(date_paid__isnull=False)
         return queryset
 
+    def filter_reminders_sent(self, queryset, _name, value):
+        if value == 0:
+            return queryset.filter(
+                date_first_reminder__isnull=True, date_second_reminder__isnull=True
+            )
+        elif value == 1:
+            return queryset.filter(
+                date_first_reminder__isnull=False, date_second_reminder__isnull=True
+            )
+        elif value == 2:
+            return queryset.filter(
+                date_first_reminder__isnull=False, date_second_reminder__isnull=False
+            )
+        else:
+            return queryset
+
     class Meta:
         model = Invoice
-        fields = ["country_id", "year", "status"]
+        fields = ["country_id", "year", "status", "reminders_sent"]
 
 
 class PaymentFilter(filters.FilterSet):

--- a/core/api/filters/replenishment.py
+++ b/core/api/filters/replenishment.py
@@ -1,6 +1,6 @@
 from django_filters import rest_framework as filters
 from django_filters.widgets import CSVWidget
-from django.db.models import Exists, OuterRef, Subquery
+from django.db.models import OuterRef, Subquery
 
 from core.models import Country, Invoice, Payment, ScaleOfAssessment
 
@@ -52,8 +52,8 @@ class InvoiceFilter(filters.FilterSet):
             return queryset.filter(
                 date_first_reminder__isnull=False, date_second_reminder__isnull=False
             )
-        else:
-            return queryset
+
+        return queryset
 
     def filter_opted_for_ferm(self, queryset, _name, value):
         # `queryset` is of Invoice

--- a/core/api/tests/test_replenishment.py
+++ b/core/api/tests/test_replenishment.py
@@ -2066,7 +2066,7 @@ class TestInvoices(BaseTest):
         assert len(response_2.data) == 1
         assert response_2.data[0]["number"] == "aaa-yyy-2"
 
-    def test_invoices_filter_reminders(self, treasurer_user):
+    def test_invoices_filters(self, treasurer_user):
         country_1 = CountryFactory.create(name="Country 1", iso3="XYZ")
         country_2 = CountryFactory.create(name="Country 2", iso3="ABC")
 
@@ -2082,9 +2082,15 @@ class TestInvoices(BaseTest):
         version_2 = ScaleOfAssessmentVersionFactory.create(
             replenishment=replenishment_2, version=0, is_final=True
         )
-        ScaleOfAssessmentFactory.create(country=country_1, version=version_1)
-        ScaleOfAssessmentFactory.create(country=country_1, version=version_2)
-        ScaleOfAssessmentFactory.create(country=country_2, version=version_2)
+        ScaleOfAssessmentFactory.create(
+            country=country_1, version=version_1, opted_for_ferm=True
+        )
+        ScaleOfAssessmentFactory.create(
+            country=country_1, version=version_2, opted_for_ferm=False
+        )
+        ScaleOfAssessmentFactory.create(
+            country=country_2, version=version_2, opted_for_ferm=False
+        )
 
         InvoiceFactory(
             country=country_1,
@@ -2139,6 +2145,17 @@ class TestInvoices(BaseTest):
         # to the response. Normally the data should only have one item.
         assert len(response_3.data) == 2
         assert response_3.data[0]["number"] == "aaa-yyy-3"
+
+        response_ferm_1 = self.client.get(
+            self.url, {"year": self.year_1, "opted_for_ferm": True}
+        )
+        assert len(response_ferm_1.data) == 2
+
+        response_ferm_2 = self.client.get(
+            self.url, {"year": self.year_2, "opted_for_ferm": True}
+        )
+        assert len(response_ferm_2.data) == 1
+        assert response_ferm_2.data[0].get("number") == None
 
     def test_invoices_create(self, treasurer_user):
         country = CountryFactory.create(name="Country 1", iso3="XYZ")

--- a/core/api/tests/test_replenishment.py
+++ b/core/api/tests/test_replenishment.py
@@ -2155,7 +2155,7 @@ class TestInvoices(BaseTest):
             self.url, {"year": self.year_2, "opted_for_ferm": True}
         )
         assert len(response_ferm_2.data) == 1
-        assert response_ferm_2.data[0].get("number") == None
+        assert response_ferm_2.data[0].get("number") is None
 
     def test_invoices_create(self, treasurer_user):
         country = CountryFactory.create(name="Country 1", iso3="XYZ")


### PR DESCRIPTION
- `reminders_sent` - can filter Invoices based on number of reminders sent (0, 1 or 2)
- `opted_for_ferm` - can filter Invoices based on whether country opted for FERM in the Invoice's year

TODO: filters should also apply for the non-invoiced countries list that we return together with the invoices!