### PR TITLE
Add cluster, type query params to type/sector listing endpoints

### DIFF
--- a/core/api/serializers/project.py
+++ b/core/api/serializers/project.py
@@ -1,5 +1,4 @@
 from django.db import transaction
-from django.urls import reverse
 
 from rest_framework import serializers
 from rest_framework.fields import empty
@@ -14,8 +13,7 @@ from core.api.serializers.project_metadata import (
 from core.models.agency import Agency
 from core.models.blend import Blend
 from core.models.country import Country
-from core.models.group import Group
-from core.models.meeting import Meeting, Decision
+from core.models.meeting import Meeting
 from core.models.project import (
     MetaProject,
     Project,
@@ -263,32 +261,6 @@ class ProjectFileSerializer(serializers.ModelSerializer):
         return obj.file.name
 
 
-class ProjectV2FileSerializer(serializers.ModelSerializer):
-    download_url = serializers.SerializerMethodField()
-    name = serializers.SerializerMethodField()
-    project_id = serializers.PrimaryKeyRelatedField(
-        required=True,
-        queryset=Project.objects.all().values_list("id", flat=True),
-    )
-
-    class Meta:
-        model = ProjectFile
-        fields = [
-            "id",
-            "name",
-            "filename",
-            "date_created",
-            "download_url",
-            "project_id",
-        ]
-
-    def get_name(self, obj):
-        return obj.file.name
-
-    def get_download_url(self, obj):
-        return reverse("project-files-v2-download", args=(obj.id,))
-
-
 class ProjectListSerializer(serializers.ModelSerializer):
     """
     ProjectSerializer class
@@ -304,7 +276,7 @@ class ProjectListSerializer(serializers.ModelSerializer):
         required=False,
         queryset=Agency.objects.all().values_list("id", flat=True),
     )
-    latest_file = ProjectV2FileSerializer(many=False, read_only=True)
+    latest_file = ProjectFileSerializer(many=False, read_only=True)
     coop_agencies = AgencySerializer(many=True, read_only=True)
     sector = ProjectSectorSerializer(read_only=True)
     sector_id = serializers.PrimaryKeyRelatedField(
@@ -496,158 +468,6 @@ class ProjectListSerializer(serializers.ModelSerializer):
         return obj.meta_project.type
 
 
-class ProjectListV2Serializer(ProjectListSerializer):
-
-    group = serializers.SlugRelatedField("name", read_only=True)
-    group_id = serializers.PrimaryKeyRelatedField(
-        allow_null=True,
-        queryset=Group.objects.all().values_list("id", flat=True),
-    )
-    decision = serializers.SlugField(read_only=True)
-    decision_id = serializers.PrimaryKeyRelatedField(
-        allow_null=True,
-        queryset=Decision.objects.all().values_list("id", flat=True),
-    )
-
-    class Meta:
-        model = Project
-        fields = [
-            "id",
-            "ad_hoc_pcr",
-            "agency",
-            "agency_id",
-            "agency_remarks",
-            "aggregated_consumption",
-            "application",
-            "baseline",
-            "bp_activity",
-            "capital_cost",
-            "cluster",
-            "cluster_id",
-            "code",
-            "code_legacy",
-            "compliance",
-            "comments",
-            "contingency_cost",
-            "coop_agencies",
-            "correspondance_no",
-            "cost_effectiveness",
-            "cost_effectiveness_co2",
-            "country",
-            "country_id",
-            "date_actual",
-            "date_approved",
-            "date_completion",
-            "date_comp_revised",
-            "date_of_revision",
-            "date_per_agreement",
-            "date_per_decision",
-            "date_received",
-            "decision",
-            "decision_id",
-            "description",
-            "destruction_tehnology",
-            "effectiveness_cost",
-            "export_to",
-            "excom_provision",
-            "funds",
-            "funds_allocated",
-            "fund_disbursed",
-            "fund_disbursed_psc",
-            "funding_window",
-            "group",
-            "group_id",
-            "impact",
-            "impact_co2mt",
-            "impact_production",
-            "impact_prod_co2mt",
-            "incomplete",
-            "intersessional_approval",
-            "individual_consideration",
-            "is_lvc",
-            "is_sme",
-            "issue",
-            "issue_description",
-            "hcfc_stage",
-            "latest_file",
-            "lead_agency",
-            "lead_agency_id",
-            "loan",
-            "local_ownership",
-            "metaproject_code",
-            "metaproject_category",
-            "meeting",
-            "meeting_id",
-            "meeting_transf",
-            "meeting_transf_id",
-            "mya_code",
-            "mya_subsector",
-            "mya_start_date",
-            "mya_end_date",
-            "mya_phase_out_co2_eq_t",
-            "mya_phase_out_odp_t",
-            "mya_phase_out_mt",
-            "mya_project_funding",
-            "mya_support_cost",
-            "national_agency",
-            "ods_odp",
-            "ods_phasedout_co2mt",
-            "operating_cost",
-            "pcr_waived",
-            "plan",
-            "plus",
-            "production_control_type",
-            "project_cost",
-            "products_manufactured",
-            "project_duration",
-            "project_end_date",
-            "project_start_date",
-            "project_type",
-            "project_type_id",
-            "project_type_legacy",
-            "programme_officer",
-            "rbm_measures",
-            "remarks",
-            "retroactive_finance",
-            "reviewed_mfs",
-            "revision_number",
-            "sector",
-            "sector_id",
-            "sector_legacy",
-            "serial_number",
-            "status",
-            "status_id",
-            "stage",
-            "starting_point",
-            "submission_amounts",
-            "submission_category",
-            "submission_comments",
-            "submission_number",
-            "substance_name",
-            "submission_status",
-            "submission_status_id",
-            "substance_type",
-            "substance_category",
-            "substance_phasedout",
-            "subsector",
-            "subsector_id",
-            "subsector_legacy",
-            "support_cost_psc",
-            "targets",
-            "technology",
-            "title",
-            "tranche",
-            "total_fund_transferred",
-            "total_fund",
-            "total_fund_approved",
-            "total_grant",
-            "total_psc_cost",
-            "total_psc_transferred",
-            "umbrella_project",
-            "withdrawn",
-        ]
-
-
 class ProjectExportSerializer(ProjectListSerializer):
     sector = serializers.SlugRelatedField("name", read_only=True)
     project_type = serializers.SlugRelatedField("name", read_only=True)
@@ -818,121 +638,3 @@ class ProjectDetailsSerializer(ProjectListSerializer):
         instance.save()
 
         return instance
-
-
-class ProjectDetailsV2Serializer(ProjectListV2Serializer):
-    """
-    ProjectSerializer class
-    """
-
-    country_id = serializers.PrimaryKeyRelatedField(
-        required=True, queryset=Country.objects.all().values_list("id", flat=True)
-    )
-    coop_agencies_id = serializers.PrimaryKeyRelatedField(
-        queryset=Agency.objects.all().values_list("id", flat=True),
-        many=True,
-        write_only=True,
-    )
-    latest_file = ProjectFileSerializer(many=False, read_only=True)
-    meeting_id = serializers.PrimaryKeyRelatedField(
-        required=True, queryset=Meeting.objects.all().values_list("id", flat=True)
-    )
-    meeting_transf_id = serializers.PrimaryKeyRelatedField(
-        required=False, queryset=Meeting.objects.all().values_list("id", flat=True)
-    )
-    cluster_id = serializers.PrimaryKeyRelatedField(
-        required=False,
-        queryset=ProjectCluster.objects.all().values_list("id", flat=True),
-    )
-
-    class Meta:
-        model = Project
-        fields = ProjectListV2Serializer.Meta.fields + [
-            "country_id",
-            "coop_agencies_id",
-            "meeting_id",
-            "meeting_transf_id",
-            "cluster_id",
-            "latest_file",
-        ]
-
-
-class ProjectV2CreateSerializer(serializers.ModelSerializer):
-    """
-    ProjectSerializer class
-    """
-
-    class Meta:
-        model = Project
-        fields = [
-            "ad_hoc_pcr",
-            "agency",
-            "aggregated_consumption",
-            "baseline",
-            "bp_activity",
-            "cluster",
-            "cost_effectiveness",
-            "cost_effectiveness_co2",
-            "country",
-            "date_approved",
-            "date_completion",
-            "decision",
-            "description",
-            "destruction_tehnology",
-            "excom_provision",
-            "funding_window",
-            "group",
-            "individual_consideration",
-            "is_lvc",
-            "is_sme",
-            "lead_agency",
-            "meeting",
-            "mya_start_date",
-            "mya_end_date",
-            "mya_phase_out_co2_eq_t",
-            "mya_phase_out_odp_t",
-            "mya_phase_out_mt",
-            "mya_project_funding",
-            "mya_support_cost",
-            "pcr_waived",
-            "production_control_type",
-            "products_manufactured",
-            "programme_officer",
-            "project_end_date",
-            "project_start_date",
-            "project_type",
-            "starting_point",
-            "sector",
-            "subsector",
-            "support_cost_psc",
-            "targets",
-            "tranche",
-            "title",
-            "total_fund",
-        ]
-
-    def to_representation(self, instance):
-        return ProjectDetailsV2Serializer(context=self.context).to_representation(
-            instance
-        )
-
-    @transaction.atomic
-    def create(self, validated_data):
-        status = ProjectStatus.objects.get(code="NA")
-        submission_status = ProjectSubmissionStatus.objects.get(name="Draft")
-        validated_data["status_id"] = status.id
-        validated_data["submission_status_id"] = submission_status.id
-        project = Project.objects.create(**validated_data)
-        # set subcode
-        project.code = get_project_sub_code(
-            project.country,
-            project.cluster,
-            project.agency,
-            project.project_type,
-            project.sector,
-            project.meeting,
-            project.meeting_transf,
-            project.serial_number,
-        )
-        project.save()
-        return project

--- a/core/api/serializers/project_v2.py
+++ b/core/api/serializers/project_v2.py
@@ -1,0 +1,316 @@
+from django.db import transaction
+from django.urls import reverse
+
+from rest_framework import serializers
+
+from core.api.serializers.project import ProjectListSerializer
+from core.models.agency import Agency
+from core.models.country import Country
+from core.models.group import Group
+from core.models.meeting import Meeting, Decision
+from core.models.project import (
+    Project,
+    ProjectFile,
+)
+from core.models.project_metadata import (
+    ProjectCluster,
+    ProjectStatus,
+    ProjectSubmissionStatus,
+)
+from core.utils import get_project_sub_code
+
+
+class ProjectV2FileSerializer(serializers.ModelSerializer):
+    download_url = serializers.SerializerMethodField()
+    name = serializers.SerializerMethodField()
+    project_id = serializers.PrimaryKeyRelatedField(
+        required=True,
+        queryset=Project.objects.all().values_list("id", flat=True),
+    )
+
+    class Meta:
+        model = ProjectFile
+        fields = [
+            "id",
+            "name",
+            "filename",
+            "date_created",
+            "download_url",
+            "project_id",
+        ]
+
+    def get_name(self, obj):
+        return obj.file.name
+
+    def get_download_url(self, obj):
+        return reverse("project-files-v2-download", args=(obj.id,))
+
+
+class ProjectListV2Serializer(ProjectListSerializer):
+
+    group = serializers.SlugRelatedField("name", read_only=True)
+    group_id = serializers.PrimaryKeyRelatedField(
+        allow_null=True,
+        queryset=Group.objects.all().values_list("id", flat=True),
+    )
+    decision = serializers.SlugField(read_only=True)
+    decision_id = serializers.PrimaryKeyRelatedField(
+        allow_null=True,
+        queryset=Decision.objects.all().values_list("id", flat=True),
+    )
+
+    class Meta:
+        model = Project
+        fields = [
+            "id",
+            "ad_hoc_pcr",
+            "agency",
+            "agency_id",
+            "agency_remarks",
+            "aggregated_consumption",
+            "application",
+            "baseline",
+            "bp_activity",
+            "capital_cost",
+            "cluster",
+            "cluster_id",
+            "code",
+            "code_legacy",
+            "compliance",
+            "comments",
+            "contingency_cost",
+            "coop_agencies",
+            "correspondance_no",
+            "cost_effectiveness",
+            "cost_effectiveness_co2",
+            "country",
+            "country_id",
+            "date_actual",
+            "date_approved",
+            "date_completion",
+            "date_comp_revised",
+            "date_of_revision",
+            "date_per_agreement",
+            "date_per_decision",
+            "date_received",
+            "decision",
+            "decision_id",
+            "description",
+            "destruction_tehnology",
+            "effectiveness_cost",
+            "export_to",
+            "excom_provision",
+            "funds",
+            "funds_allocated",
+            "fund_disbursed",
+            "fund_disbursed_psc",
+            "funding_window",
+            "group",
+            "group_id",
+            "impact",
+            "impact_co2mt",
+            "impact_production",
+            "impact_prod_co2mt",
+            "incomplete",
+            "intersessional_approval",
+            "individual_consideration",
+            "is_lvc",
+            "is_sme",
+            "issue",
+            "issue_description",
+            "hcfc_stage",
+            "latest_file",
+            "lead_agency",
+            "lead_agency_id",
+            "loan",
+            "local_ownership",
+            "metaproject_code",
+            "metaproject_category",
+            "meeting",
+            "meeting_id",
+            "meeting_transf",
+            "meeting_transf_id",
+            "mya_code",
+            "mya_subsector",
+            "mya_start_date",
+            "mya_end_date",
+            "mya_phase_out_co2_eq_t",
+            "mya_phase_out_odp_t",
+            "mya_phase_out_mt",
+            "mya_project_funding",
+            "mya_support_cost",
+            "national_agency",
+            "ods_odp",
+            "ods_phasedout_co2mt",
+            "operating_cost",
+            "pcr_waived",
+            "plan",
+            "plus",
+            "production_control_type",
+            "project_cost",
+            "products_manufactured",
+            "project_duration",
+            "project_end_date",
+            "project_start_date",
+            "project_type",
+            "project_type_id",
+            "project_type_legacy",
+            "programme_officer",
+            "rbm_measures",
+            "remarks",
+            "retroactive_finance",
+            "reviewed_mfs",
+            "revision_number",
+            "sector",
+            "sector_id",
+            "sector_legacy",
+            "serial_number",
+            "status",
+            "status_id",
+            "stage",
+            "starting_point",
+            "submission_amounts",
+            "submission_category",
+            "submission_comments",
+            "submission_number",
+            "substance_name",
+            "submission_status",
+            "submission_status_id",
+            "substance_type",
+            "substance_category",
+            "substance_phasedout",
+            "subsector",
+            "subsector_id",
+            "subsector_legacy",
+            "support_cost_psc",
+            "targets",
+            "technology",
+            "title",
+            "tranche",
+            "total_fund_transferred",
+            "total_fund",
+            "total_fund_approved",
+            "total_grant",
+            "total_psc_cost",
+            "total_psc_transferred",
+            "umbrella_project",
+            "withdrawn",
+        ]
+
+
+class ProjectDetailsV2Serializer(ProjectListV2Serializer):
+    """
+    ProjectSerializer class
+    """
+
+    country_id = serializers.PrimaryKeyRelatedField(
+        required=True, queryset=Country.objects.all().values_list("id", flat=True)
+    )
+    coop_agencies_id = serializers.PrimaryKeyRelatedField(
+        queryset=Agency.objects.all().values_list("id", flat=True),
+        many=True,
+        write_only=True,
+    )
+    latest_file = ProjectV2FileSerializer(many=False, read_only=True)
+    meeting_id = serializers.PrimaryKeyRelatedField(
+        required=True, queryset=Meeting.objects.all().values_list("id", flat=True)
+    )
+    meeting_transf_id = serializers.PrimaryKeyRelatedField(
+        required=False, queryset=Meeting.objects.all().values_list("id", flat=True)
+    )
+    cluster_id = serializers.PrimaryKeyRelatedField(
+        required=False,
+        queryset=ProjectCluster.objects.all().values_list("id", flat=True),
+    )
+
+    class Meta:
+        model = Project
+        fields = ProjectListV2Serializer.Meta.fields + [
+            "country_id",
+            "coop_agencies_id",
+            "meeting_id",
+            "meeting_transf_id",
+            "cluster_id",
+            "latest_file",
+        ]
+
+
+class ProjectV2CreateSerializer(serializers.ModelSerializer):
+    """
+    ProjectSerializer class
+    """
+
+    class Meta:
+        model = Project
+        fields = [
+            "ad_hoc_pcr",
+            "agency",
+            "aggregated_consumption",
+            "baseline",
+            "bp_activity",
+            "cluster",
+            "cost_effectiveness",
+            "cost_effectiveness_co2",
+            "country",
+            "date_approved",
+            "date_completion",
+            "decision",
+            "description",
+            "destruction_tehnology",
+            "excom_provision",
+            "funding_window",
+            "group",
+            "individual_consideration",
+            "is_lvc",
+            "is_sme",
+            "lead_agency",
+            "meeting",
+            "mya_start_date",
+            "mya_end_date",
+            "mya_phase_out_co2_eq_t",
+            "mya_phase_out_odp_t",
+            "mya_phase_out_mt",
+            "mya_project_funding",
+            "mya_support_cost",
+            "pcr_waived",
+            "production_control_type",
+            "products_manufactured",
+            "programme_officer",
+            "project_end_date",
+            "project_start_date",
+            "project_type",
+            "starting_point",
+            "sector",
+            "subsector",
+            "support_cost_psc",
+            "targets",
+            "tranche",
+            "title",
+            "total_fund",
+        ]
+
+    def to_representation(self, instance):
+        return ProjectDetailsV2Serializer(context=self.context).to_representation(
+            instance
+        )
+
+    @transaction.atomic
+    def create(self, validated_data):
+        status = ProjectStatus.objects.get(code="NA")
+        submission_status = ProjectSubmissionStatus.objects.get(name="Draft")
+        validated_data["status_id"] = status.id
+        validated_data["submission_status_id"] = submission_status.id
+        project = Project.objects.create(**validated_data)
+        # set subcode
+        project.code = get_project_sub_code(
+            project.country,
+            project.cluster,
+            project.agency,
+            project.project_type,
+            project.sector,
+            project.meeting,
+            project.meeting_transf,
+            project.serial_number,
+        )
+        project.save()
+        return project

--- a/core/api/views/projects_v2.py
+++ b/core/api/views/projects_v2.py
@@ -13,11 +13,11 @@ from rest_framework import parsers
 
 from core.api.filters.project import ProjectFilter
 from core.api.permissions import IsAgency, IsCountryUser, IsSecretariat, IsViewer
-from core.api.serializers.project import (
+from core.api.serializers.project_v2 import (
+    ProjectV2FileSerializer,
     ProjectDetailsV2Serializer,
     ProjectListV2Serializer,
     ProjectV2CreateSerializer,
-    ProjectV2FileSerializer,
 )
 from core.api.swagger import FileUploadAutoSchema
 from core.models.project import (

--- a/core/api/views/sector_subsector.py
+++ b/core/api/views/sector_subsector.py
@@ -1,12 +1,19 @@
 from rest_framework import mixins, viewsets, status
 from rest_framework.response import Response
 
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
+
 from core.api.permissions import IsAgency, IsSecretariat, IsViewer
 from core.api.serializers.project_metadata import (
     ProjectSectorSerializer,
     ProjectSubSectorSerializer,
 )
-from core.models.project_metadata import ProjectSector, ProjectSubSector
+from core.models.project_metadata import (
+    ProjectClusterTypeSectorFields,
+    ProjectSector,
+    ProjectSubSector,
+)
 
 # please make sure to use only this endpoint for sector and subsector list
 # we need to make sure that we filter out the custom sectors and subsectors
@@ -73,6 +80,47 @@ class ProjectSectorView(SectorSubsectorBaseView):
     def get_existing_object(self, request):
         return ProjectSector.objects.find_by_name(request.data["name"])
 
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        if self.request.method == "GET":
+            cluster_id = self.request.query_params.get("cluster_id")
+            type_id = self.request.query_params.get("type_id")
+
+            if cluster_id and type_id:
+                queryset = queryset.filter(
+                    id__in=ProjectClusterTypeSectorFields.objects.filter(
+                        cluster_id=cluster_id, type_id=type_id
+                    ).values_list("sector_id", flat=True)
+                ).order_by("sort_order")
+        return queryset
+
+    @swagger_auto_schema(
+        manual_parameters=[
+            openapi.Parameter(
+                "cluster_id",
+                openapi.IN_QUERY,
+                description="Filter sector by cluster ID. Must be used with type_id.",
+                type=openapi.TYPE_INTEGER,
+            ),
+            openapi.Parameter(
+                "type_id",
+                openapi.IN_QUERY,
+                description="Filter sector by type ID. Must be used with cluster_id.",
+                type=openapi.TYPE_INTEGER,
+            ),
+        ]
+    )
+    def list(self, request, *args, **kwargs):
+        cluster_id = request.query_params.get("cluster_id")
+        type_id = request.query_params.get("type_id")
+
+        if any([cluster_id, type_id]) and not all([cluster_id, type_id]):
+            return Response(
+                {"error": "Both cluster_id and type_id must be provided together."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        return super().list(request, *args, **kwargs)
 
 class ProjectSubSectorView(SectorSubsectorBaseView):
     """


### PR DESCRIPTION
* Adding cluster_id query parameter to `api/project-types` listing endpoint to filter the list of types based on the existing entries with the given cluster in ProjectClusterTypeSectorFields.

* Adding cluster_id and type_id query_parameters to `api/project-sector` listing to filter the list of sectors based on the existing entries with the given cluster and type in ProjectClusterTypeSectorFields.