### PR TITLE
Add submit and recommend project endpoints

### DIFF
--- a/core/api/serializers/project_v2.py
+++ b/core/api/serializers/project_v2.py
@@ -604,11 +604,7 @@ class ProjectV2SubmitSerializer(serializers.ModelSerializer):
             "version",
         ]
 
-    def validate(self, attrs):
-        """
-        Validate the project submission
-        """
-        errors = {}
+    def validate_required_fields(self, errors):
         mandatory_fields_at_submission = [
             "cluster",
             "project_type",
@@ -624,13 +620,6 @@ class ProjectV2SubmitSerializer(serializers.ModelSerializer):
             "total_fund",
             "support_cost_psc",
         ]
-        if self.instance.version != 1:
-            errors["version"] = "Project can only be submitted if it is version 1."
-        if self.instance.submission_status.name != "Draft":
-            errors["submission_status"] = (
-                "Project can only be submitted if its status is Draft."
-            )
-
         for field in mandatory_fields_at_submission:
             if getattr(self.instance, field) is None:
                 errors[field] = (
@@ -669,7 +658,50 @@ class ProjectV2SubmitSerializer(serializers.ModelSerializer):
             errors["files"] = (
                 "At least one file must be attached to the project for submission."
             )
+        return errors
 
+    def validate(self, attrs):
+        """
+        Validate the project submission
+        """
+        errors = {}
+        if self.instance.version != 1:
+            errors["version"] = "Project can only be submitted if it is version 1."
+        if self.instance.submission_status.name != "Draft":
+            errors["submission_status"] = (
+                "Project can only be submitted if its status is Draft."
+            )
+
+        self.validate_required_fields(errors)
+        if errors:
+            raise serializers.ValidationError(errors)
+        return attrs
+
+
+class ProjectV2RecommendSerializer(ProjectV2SubmitSerializer):
+    """
+    ProjectSerializer class for recommending a project
+    """
+
+    class Meta:
+        model = Project
+        fields = [
+            "version",
+        ]
+
+    def validate(self, attrs):
+        """
+        Validate the project submission
+        """
+        errors = {}
+        if self.instance.version != 2:
+            errors["version"] = "Project can only be recommended if it is version 2."
+        if self.instance.submission_status.name != "Submitted":
+            errors["submission_status"] = (
+                "Project can only be recommended if its status is Submitted."
+            )
+
+        self.validate_required_fields(errors)
         if errors:
             raise serializers.ValidationError(errors)
         return attrs

--- a/core/api/serializers/project_v2.py
+++ b/core/api/serializers/project_v2.py
@@ -19,11 +19,14 @@ from core.models.project import (
 )
 from core.models.project_metadata import (
     ProjectCluster,
+    ProjectSpecificFields,
     ProjectStatus,
     ProjectSubmissionStatus,
     ProjectSubSector,
 )
 from core.utils import get_project_sub_code
+
+# pylint: disable=R1702
 
 
 HISTORY_DESCRIPTION_CREATE = "Project created."
@@ -588,3 +591,85 @@ class ProjectV2CreateUpdateSerializer(serializers.ModelSerializer):
         history_serializer = ProjectHistorySerializer(data=history_data)
         history_serializer.is_valid(raise_exception=True)
         history_serializer.save(user=request_user)
+
+
+class ProjectV2SubmitSerializer(serializers.ModelSerializer):
+    """
+    ProjectSerializer class for submitting a project
+    """
+
+    class Meta:
+        model = Project
+        fields = [
+            "version",
+        ]
+
+    def validate(self, attrs):
+        """
+        Validate the project submission
+        """
+        errors = {}
+        mandatory_fields_at_submission = [
+            "cluster",
+            "project_type",
+            "sector",
+            "country",
+            "agency",
+            "meeting",
+            "is_lvc",
+            "title",
+            "description",
+            "project_start_date",
+            "project_end_date",
+            "total_fund",
+            "support_cost_psc",
+        ]
+        if self.instance.version != 1:
+            errors["version"] = "Project can only be submitted if it is version 1."
+        if self.instance.submission_status.name != "Draft":
+            errors["submission_status"] = (
+                "Project can only be submitted if its status is Draft."
+            )
+
+        for field in mandatory_fields_at_submission:
+            if getattr(self.instance, field) is None:
+                errors[field] = (
+                    f"{field.replace('_', ' ').title()} is required for submission."
+                )
+
+        # Check project specific mandatory fields
+        project_specific_fields_obj = ProjectSpecificFields.objects.filter(
+            cluster=self.instance.cluster,
+            type=self.instance.project_type,
+            sector=self.instance.sector,
+        ).first()
+
+        if project_specific_fields_obj:
+            for field in project_specific_fields_obj.fields.filter(
+                section__in=["Header", "Substance Details", "Impact"]
+            ):
+                if field.section == "Substance Details":
+                    project_ods_odp_entries = self.instance.ods_odp.all()
+                    if not project_ods_odp_entries:
+                        errors[field.write_field_name] = (
+                            f"{field.label} is required for submission."
+                        )
+                    else:
+                        for ods_odp in project_ods_odp_entries:
+                            if getattr(ods_odp, field.write_field_name) is None:
+                                errors[f"{field.write_field_name}_ods_odp"] = (
+                                    f"{field.label} is required for submission."
+                                )
+                else:
+                    if not getattr(self.instance, field.write_field_name):
+                        errors[field.write_field_name] = (
+                            f"{field.label} is required for submission."
+                        )
+        if ProjectFile.objects.filter(project=self.instance).count() < 1:
+            errors["files"] = (
+                "At least one file must be attached to the project for submission."
+            )
+
+        if errors:
+            raise serializers.ValidationError(errors)
+        return attrs

--- a/core/api/tests/conftest.py
+++ b/core/api/tests/conftest.py
@@ -374,9 +374,16 @@ def project_status():
 
 
 @pytest.fixture
-def project_submission_status():
+def project_draft_status():
     return ProjectSubmissionStatusFactory.create(
         name="Draft", code="draft", color="#FF0000"
+    )
+
+
+@pytest.fixture
+def project_submitted_status():
+    return ProjectSubmissionStatusFactory.create(
+        name="Submitted", code="submitted", color="#00FF00"
     )
 
 
@@ -444,7 +451,7 @@ def project(
     agency,
     project_type,
     project_status,
-    project_submission_status,
+    project_draft_status,
     sector,
     subsector,
     meeting,
@@ -461,7 +468,7 @@ def project(
         agency=agency,
         project_type=project_type,
         status=project_status,
-        submission_status=project_submission_status,
+        submission_status=project_draft_status,
         sector=sector,
         subsectors=[subsector],
         meeting=meeting,

--- a/core/api/tests/test_users.py
+++ b/core/api/tests/test_users.py
@@ -41,20 +41,38 @@ class TestUserPermissions(BaseTest):
         _test_user_permissions(viewer_user, ["view_project"])
         _test_user_permissions(
             agency_user,
-            ["add_project", "edit_project", "increase_project_version", "view_project"],
+            [
+                "add_project",
+                "edit_project",
+                "increase_project_version",
+                "submit_project",
+                "view_project",
+            ],
         )
         _test_user_permissions(
             agency_inputter_user,
-            ["add_project", "edit_project", "increase_project_version", "view_project"],
+            ["add_project", "edit_project", "view_project"],
         )
         _test_user_permissions(secretariat_viewer_user, ["view_project"])
         _test_user_permissions(
             secretariat_v1_v2_edit_access_user,
-            ["add_project", "edit_project", "increase_project_version", "view_project"],
+            [
+                "add_project",
+                "edit_project",
+                "increase_project_version",
+                "submit_project",
+                "view_project",
+            ],
         )
         _test_user_permissions(
             secretariat_production_v1_v2_edit_access_user,
-            ["add_project", "edit_project", "increase_project_version", "view_project"],
+            [
+                "add_project",
+                "edit_project",
+                "increase_project_version",
+                "submit_project",
+                "view_project",
+            ],
         )
         _test_user_permissions(
             secretariat_v3_edit_access_user,
@@ -66,5 +84,11 @@ class TestUserPermissions(BaseTest):
         )
         _test_user_permissions(
             admin_user,
-            ["add_project", "edit_project", "increase_project_version", "view_project"],
+            [
+                "add_project",
+                "edit_project",
+                "increase_project_version",
+                "submit_project",
+                "view_project",
+            ],
         )

--- a/core/api/views/projects_v2.py
+++ b/core/api/views/projects_v2.py
@@ -1,10 +1,8 @@
 import os
 import urllib
-import shutil
 
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
-from django.db import transaction
 from django.db.models import Q
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
@@ -27,6 +25,7 @@ from core.api.permissions import (
     IsViewer,
 )
 from core.api.serializers.project_v2 import (
+    ProjectV2SubmitSerializer,
     ProjectV2FileSerializer,
     ProjectDetailsV2Serializer,
     ProjectListV2Serializer,
@@ -35,16 +34,11 @@ from core.api.serializers.project_v2 import (
 from core.api.swagger import FileUploadAutoSchema
 from core.models.project import (
     Project,
-    ProjectComment,
-    ProjectFund,
-    ProjectRBMMeasure,
     ProjectOdsOdp,
-    ProjectProgressReport,
     ProjectFile,
-    SubmissionAmount,
 )
+from core.models.project_metadata import ProjectSubmissionStatus
 from core.models.user import User
-from core.models.utils import get_protected_storage
 
 
 class ProjectDestructionTechnologyView(APIView):
@@ -131,11 +125,19 @@ class ProjectV2ViewSet(
             "update",
             "partial_update",
             "destroy",
-            "increase_version",
         ]:
             return [
                 IsAgencyInputter
                 | IsAgencySubmitter
+                | IsSecretariatV1V2EditAccess
+                | IsSecretariatProductionV1V2EditAccess
+            ]
+        if self.action in [
+            "increase_version",
+            "submit",
+        ]:
+            return [
+                IsAgencySubmitter
                 | IsSecretariatV1V2EditAccess
                 | IsSecretariatProductionV1V2EditAccess
             ]
@@ -260,12 +262,6 @@ class ProjectV2ViewSet(
         data = meta.determine_metadata(request, self)
         return Response(data)
 
-    def _get_new_file_path(self, original_file_name, new_project_id):
-        # Generate a new file path for the duplicated file
-        base_dir, file_name = os.path.split(original_file_name)
-        new_file_name = f"{file_name}_{new_project_id}"
-        return os.path.join(base_dir, new_file_name)
-
     @action(methods=["POST"], detail=True)
     @swagger_auto_schema(
         operation_description="""
@@ -289,78 +285,51 @@ class ProjectV2ViewSet(
                 {"error": "This project already has a latest version."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        with transaction.atomic():
-            # Duplicate the project
-            old_project = Project.objects.get(pk=project.pk)
-            old_project.pk = None
-            old_project.latest_project = project
+        project.increase_version(request.user)
 
-            old_project.save()
+        return Response(
+            ProjectDetailsV2Serializer(project).data,
+            status=status.HTTP_200_OK,
+        )
 
-            project.version += 1
-            project.version_created_by = request.user
-            project.save()
-
-            # Duplicate the linked ProjectOdsOdp entries
-            ods_odp_entries = ProjectOdsOdp.objects.filter(project=project)
-            for entry in ods_odp_entries:
-                entry.pk = None
-                entry.project = old_project
-                entry.save()
-
-            # Duplicate the linked ProjectFund entries
-            fund_entries = ProjectFund.objects.filter(project=project)
-            for entry in fund_entries:
-                entry.pk = None
-                entry.project = old_project
-                entry.save()
-
-            # Duplicate the linked ProjectRBMMeasure entries
-            rbm_entries = ProjectRBMMeasure.objects.filter(project=project)
-            for entry in rbm_entries:
-                entry.pk = None
-                entry.project = old_project
-                entry.save()
-
-            # Duplicate the linked ProjectProgressReport entries
-            progress_report_entries = ProjectProgressReport.objects.filter(
-                project=project
-            )
-            for entry in progress_report_entries:
-                entry.pk = None
-                entry.project = old_project
-                entry.save()
-
-            # Duplicate the linked SubmissionAmount entries
-            submission_amount_entries = SubmissionAmount.objects.filter(project=project)
-            for entry in submission_amount_entries:
-                entry.pk = None
-                entry.project = old_project
-                entry.save()
-
-            # Duplicate the ProjectComment entries
-            comment_entries = ProjectComment.objects.filter(project=project)
-            for entry in comment_entries:
-                entry.pk = None
-                entry.project = old_project
-                entry.save()
-
-            # Duplicate the ProjectFile entries
-            file_entries = ProjectFile.objects.filter(project=project)
-            for entry in file_entries:
-                original_file_path = entry.file.path
-                new_file_path = self._get_new_file_path(entry.file.name, old_project.id)
-                storage = get_protected_storage()
-                with storage.open(original_file_path, "rb") as original_file:
-                    with storage.open(new_file_path, "wb") as new_file:
-                        shutil.copyfileobj(original_file, new_file)
-                entry.pk = None
-                entry.project = old_project
-                entry.file.name = (
-                    new_file_path  # Update the file field to point to the new file
-                )
-                entry.save()
-
+    @action(methods=["POST"], detail=True)
+    @swagger_auto_schema(
+        operation_description="""
+            This endpoint archives the project by creating a copy of it and
+            increasing the version of the original entry.
+            The related entries (ProjectOdsOdp, ProjectFund, ProjectRBMMeasure,
+            ProjectProgressReport, SubmissionAmount, ProjectComment, ProjectFile)
+            are also duplicated and linked to the archived project.
+            The file itself is also duplicated and linked to the archived project.
+        """,
+        request_body=openapi.Schema(type=openapi.TYPE_OBJECT, properties=None),
+        responses={
+            status.HTTP_200_OK: ProjectDetailsV2Serializer,
+            status.HTTP_400_BAD_REQUEST: "Bad request",
+        },
+    )
+    def submit(self, request, *args, **kwargs):
+        """
+        Submit the project for review.
+        The project is checked for validity (check version, status and if the required fields are filled).
+        If the project is valid, it is marked as submitted and the version is increased, creating an
+        archived version of the project.
+        The related entries (ProjectOdsOdp, ProjectFund, ProjectRBMMeasure,
+        ProjectProgressReport, SubmissionAmount, ProjectComment, ProjectFile)
+        are also duplicated and linked to the archived project.
+        An email notification is sent to the secretariat team
+        to inform them about the new submission. (TO BE IMPLEMENTED)
+        """
+        project = self.get_object()
+        serializer = ProjectV2SubmitSerializer(project, data={}, partial=True)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        project.submission_status = ProjectSubmissionStatus.objects.get(
+            name="Submitted"
+        )
+        project.save()
+        project.increase_version(request.user)
+        # TODO: Implement MLFS notifications
         return Response(
             ProjectDetailsV2Serializer(project).data,
             status=status.HTTP_200_OK,

--- a/core/api/views/users.py
+++ b/core/api/views/users.py
@@ -20,7 +20,6 @@ class UserPermissionsView(views.APIView):
             ]
 
         if self.request.user.user_type in [
-            User.UserType.AGENCY_INPUTTER,
             User.UserType.AGENCY_SUBMITTER,
             User.UserType.SECRETARIAT_PRODUCTION_V1_V2_EDIT_ACCESS,
             User.UserType.SECRETARIAT_V1_V2_EDIT_ACCESS,
@@ -29,10 +28,12 @@ class UserPermissionsView(views.APIView):
                 "add_project",
                 "edit_project",
                 "increase_project_version",
+                "submit_project",
                 "view_project",
             ]
 
         if self.request.user.user_type in [
+            User.UserType.AGENCY_INPUTTER,
             User.UserType.SECRETARIAT_PRODUCTION_V3_EDIT_ACCESS,
             User.UserType.SECRETARIAT_V3_EDIT_ACCESS,
         ]:
@@ -47,6 +48,7 @@ class UserPermissionsView(views.APIView):
                 "add_project",
                 "edit_project",
                 "increase_project_version",
+                "submit_project",
                 "view_project",
             ]
 

--- a/core/models/project.py
+++ b/core/models/project.py
@@ -616,9 +616,7 @@ class Project(models.Model):
                 entry.save()
 
             # Transfer files to the archive project
-            ProjectFile.objects.filter(project=self).update(
-                project=old_project
-            )
+            ProjectFile.objects.filter(project=self).update(project=old_project)
 
     def __str__(self):
         return self.title


### PR DESCRIPTION
Add endpoint `/api/projects/v2/{id}/submit/` for submitting Project (v1 -> v2). The endpoint receives a project id and takes the following actions:
* validate that Project submission status is Draft and version is v1. Checks that all required fields are filled and at least one file exists. (returns 400 if a field is missing)
* Changes submission status from Draft to Submitted and version to 2.
* Saves an archive of the project.
* Sends a notification to MLFS (Not implemented)
* Submit is permitted only for Agency submitter, Secretariat V1 V2 Edit Access, Secretariat Production V1 V2 Edit Access, Admin


Add endpoint `/api/projects/v2/{id}/recommend/` for recommending Project (v2 -> v3). The endpoint receives a project id and takes the following actions:
* validate that Project submission status is Submitted and version is v2. Checks that all required fields are filled and at least one file exists. (returns 400 if a field is missing)
* Changes submission status from Submitted to Recommended and version to 3.
* Saves an archive of the project.
* Submit is permitted only for Secretariat V1 V2 Edit Access, Secretariat Production V1 V2 Edit Access, Admin


