### PR TITLE
Add withdraw and send project back to draft endpoints

### DIFF
--- a/core/admin/project.py
+++ b/core/admin/project.py
@@ -98,6 +98,7 @@ class ProjectAdmin(admin.ModelAdmin):
             "rbm_measures",
             "latest_project",
             "archive_projects",
+            "project_history",
         ]
         return get_final_display_list(Project, exclude)
 

--- a/core/api/serializers/project_v2.py
+++ b/core/api/serializers/project_v2.py
@@ -25,6 +25,7 @@ from core.models.project_metadata import (
     ProjectSubSector,
 )
 from core.utils import get_project_sub_code
+from core.api.views.utils import log_project_history
 
 # pylint: disable=R1702
 
@@ -520,7 +521,7 @@ class ProjectV2CreateUpdateSerializer(serializers.ModelSerializer):
 
         project.subsectors.set(subsectors_data)
 
-        self._log_history(project, user, HISTORY_DESCRIPTION_CREATE)
+        log_project_history(project, user, HISTORY_DESCRIPTION_CREATE)
 
         return project
 
@@ -552,7 +553,7 @@ class ProjectV2CreateUpdateSerializer(serializers.ModelSerializer):
         if subsectors_data is not None:
             instance.subsectors.set(subsectors_data)
 
-        self._log_history(instance, user, HISTORY_DESCRIPTION_UPDATE)
+        log_project_history(instance, user, HISTORY_DESCRIPTION_UPDATE)
 
         return instance
 
@@ -582,15 +583,6 @@ class ProjectV2CreateUpdateSerializer(serializers.ModelSerializer):
 
         if ids_to_delete:
             instance.ods_odp.filter(id__in=ids_to_delete).delete()
-
-    def _log_history(self, project, request_user, description):
-        history_data = {
-            "project_id": project.id,
-            "description": description,
-        }
-        history_serializer = ProjectHistorySerializer(data=history_data)
-        history_serializer.is_valid(raise_exception=True)
-        history_serializer.save(user=request_user)
 
 
 class ProjectV2SubmitSerializer(serializers.ModelSerializer):

--- a/core/api/tests/test_users.py
+++ b/core/api/tests/test_users.py
@@ -60,8 +60,10 @@ class TestUserPermissions(BaseTest):
                 "add_project",
                 "edit_project",
                 "increase_project_version",
+                "send_project_back_to_draft",
                 "submit_project",
                 "view_project",
+                "withdraw_project",
             ],
         )
         _test_user_permissions(
@@ -70,8 +72,10 @@ class TestUserPermissions(BaseTest):
                 "add_project",
                 "edit_project",
                 "increase_project_version",
+                "send_project_back_to_draft",
                 "submit_project",
                 "view_project",
+                "withdraw_project",
             ],
         )
         _test_user_permissions(

--- a/core/api/views/users.py
+++ b/core/api/views/users.py
@@ -21,8 +21,6 @@ class UserPermissionsView(views.APIView):
 
         if self.request.user.user_type in [
             User.UserType.AGENCY_SUBMITTER,
-            User.UserType.SECRETARIAT_PRODUCTION_V1_V2_EDIT_ACCESS,
-            User.UserType.SECRETARIAT_V1_V2_EDIT_ACCESS,
         ]:
             permissions = [
                 "add_project",
@@ -30,6 +28,20 @@ class UserPermissionsView(views.APIView):
                 "increase_project_version",
                 "submit_project",
                 "view_project",
+            ]
+
+        if self.request.user.user_type in [
+            User.UserType.SECRETARIAT_PRODUCTION_V1_V2_EDIT_ACCESS,
+            User.UserType.SECRETARIAT_V1_V2_EDIT_ACCESS,
+        ]:
+            permissions = [
+                "add_project",
+                "edit_project",
+                "increase_project_version",
+                "send_project_back_to_draft",
+                "submit_project",
+                "view_project",
+                "withdraw_project",
             ]
 
         if self.request.user.user_type in [

--- a/core/api/views/utils.py
+++ b/core/api/views/utils.py
@@ -15,16 +15,17 @@ from core.api.export.replenishment import (
     StatisticsStatusOfContributionsWriter,
 )
 from core.models import (
-    Country,
-    TriennialContributionStatus,
-    TriennialContributionView,
-    FermGainLoss,
-    BilateralAssistance,
-    DisputedContribution,
     AnnualContributionStatus,
+    BilateralAssistance,
+    Country,
+    DisputedContribution,
     ExternalIncomeAnnual,
     ExternalAllocation,
+    FermGainLoss,
     Payment,
+    ProjectHistory,
+    TriennialContributionStatus,
+    TriennialContributionView,
 )
 from core.models.business_plan import BusinessPlan
 from core.models.country_programme import CPRecord, CPReport, CPReportFormatRow
@@ -59,6 +60,14 @@ SUBSTANCE_GROUP_ID_TO_CATEGORY = {
     "uncontrolled": "Other",
     "legacy": "Legacy",
 }
+
+
+def log_project_history(project, request_user, description):
+    ProjectHistory.objects.create(
+        project=project,
+        description=description,
+        user=request_user,
+    )
 
 
 def get_country_region_dict():

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -8,6 +8,7 @@ from .country_programme_archive import *
 from .group import *
 from .project import *
 from .project_complition_report import *
+from .project_history import *
 from .project_metadata import *
 from .replenishment import *
 from .substance import *


### PR DESCRIPTION
Add endpoint `/api/projects/v2/{id}/withdraw/` for withdrawing a Project (v2). The endpoint receives a project id and takes the following actions:
* validate that Project submission status is Submitted and version is 2.
* Changes submission status from Submitted to Withdrawn
* Withdrawing is permitted only for Secretariat V1 V2 Edit Access, Secretariat Production V1 V2 Edit Access, Admin


Add endpoint `/api/projects/v2/{id}/send_back_to_draft/` for sending a submitted Project back to Draft submission status. The endpoint receives a project id and takes the following actions:
* validates that the project is Submitted and v2
* changes submission status from Submitted to Draft
* The project will remain in version 2 and all changes will be made by IA/BA will be made to version 2
* Sending back to draft is permitted only for Secretariat V1 V2 Edit Access, Secretariat Production V1 V2 Edit Access, Admin


