### PR TITLE
Add associated projects listing

### DIFF
--- a/core/admin/project.py
+++ b/core/admin/project.py
@@ -28,7 +28,13 @@ class MetaProjectAdmin(admin.ModelAdmin):
     ]
 
     def get_list_display(self, request):
-        exclude = ["project", "pcractivity", "pcrlearnedlessons", "pcrdelayexplanation"]
+        exclude = [
+            "project",
+            "pcractivity",
+            "pcrlearnedlessons",
+            "pcrdelayexplanation",
+            "projects",
+        ]
         return get_final_display_list(MetaProject, exclude)
 
 

--- a/core/api/permissions.py
+++ b/core/api/permissions.py
@@ -169,6 +169,22 @@ class IsAgencySubmitter(IsAgency):
                 return True
         return False
 
+    def has_object_permission(self, request, view, obj):
+        """
+        Check if user has permission to access the object
+
+        """
+        if getattr(obj, "agency_id", "no attr") == "no attr":
+            return False
+        if request.user.agency_id == obj.agency_id:
+            return True
+        if getattr(obj, "meta_project", "no metaproject") == "no metaproject":
+            return False
+
+        if request.user.agency == obj.meta_project.lead_agency:
+            return True
+        return False
+
 
 class IsAgencyInputter(IsAgency):
     def has_permission(self, request, view):
@@ -179,6 +195,22 @@ class IsAgencyInputter(IsAgency):
                 and user.agency_id is not None
             ):
                 return True
+        return False
+
+    def has_object_permission(self, request, view, obj):
+        """
+        Check if user has permission to access the object
+
+        """
+        if getattr(obj, "agency_id", "no attr") == "no attr":
+            return False
+        if request.user.agency_id == obj.agency_id:
+            return True
+        if getattr(obj, "meta_project", "no metaproject") == "no metaproject":
+            return False
+
+        if request.user.agency == obj.meta_project.lead_agency:
+            return True
         return False
 
 

--- a/core/api/serializers/project_association.py
+++ b/core/api/serializers/project_association.py
@@ -1,9 +1,5 @@
 from rest_framework import serializers
 
-from core.api.serializers.project import (
-    ProjectListSerializer,
-)
-
 from core.models.agency import Agency
 from core.models.project import (
     MetaProject,

--- a/core/api/serializers/project_association.py
+++ b/core/api/serializers/project_association.py
@@ -1,0 +1,35 @@
+from rest_framework import serializers
+
+from core.api.serializers.project import (
+    ProjectListSerializer,
+)
+
+from core.models.agency import Agency
+from core.models.project import (
+    MetaProject,
+)
+from core.api.serializers.project_v2 import ProjectListSerializer
+
+
+class MetaProjectSerializer(serializers.ModelSerializer):
+    """
+    Serializer for MetaProject model.
+    """
+
+    lead_agency = serializers.SlugRelatedField("name", read_only=True)
+    lead_agency_id = serializers.PrimaryKeyRelatedField(
+        required=True, queryset=Agency.objects.all().values_list("id", flat=True)
+    )
+    projects = ProjectListSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = MetaProject
+        fields = [
+            "id",
+            "lead_agency",
+            "lead_agency_id",
+            "type",
+            "code",
+            "pcr_project_id",
+            "projects",
+        ]

--- a/core/api/tests/test_project_association.py
+++ b/core/api/tests/test_project_association.py
@@ -1,25 +1,10 @@
 import pytest
 from django.urls import reverse
-from rest_framework.test import APIClient
-
-from core.api.serializers.project_metadata import ProjectSubSectorSerializer
-
-from core.api.serializers.project_v2 import HISTORY_DESCRIPTION_CREATE
-from core.api.serializers.project_v2 import HISTORY_DESCRIPTION_UPDATE
-
 from core.api.tests.base import BaseTest
 from core.api.tests.factories import (
     AgencyFactory,
-    CountryFactory,
-    MeetingFactory,
     ProjectFactory,
-    ProjectSectorFactory,
-    ProjectStatusFactory,
-    ProjectSubmissionStatusFactory,
-    ProjectSubSectorFactory,
-    ProjectTypeFactory,
 )
-from core.utils import get_project_sub_code
 
 pytestmark = pytest.mark.django_db
 # pylint: disable=C0302,C8008,W0221,R0913,R0914,R0915,W0613

--- a/core/api/tests/test_project_association.py
+++ b/core/api/tests/test_project_association.py
@@ -1,0 +1,207 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from core.api.serializers.project_metadata import ProjectSubSectorSerializer
+
+from core.api.serializers.project_v2 import HISTORY_DESCRIPTION_CREATE
+from core.api.serializers.project_v2 import HISTORY_DESCRIPTION_UPDATE
+
+from core.api.tests.base import BaseTest
+from core.api.tests.factories import (
+    AgencyFactory,
+    CountryFactory,
+    MeetingFactory,
+    ProjectFactory,
+    ProjectSectorFactory,
+    ProjectStatusFactory,
+    ProjectSubmissionStatusFactory,
+    ProjectSubSectorFactory,
+    ProjectTypeFactory,
+)
+from core.utils import get_project_sub_code
+
+pytestmark = pytest.mark.django_db
+# pylint: disable=C0302,C8008,W0221,R0913,R0914,R0915,W0613
+
+
+@pytest.fixture(name="_setup_project_list")
+def setup_project_list():
+    project = ProjectFactory.create(
+        title=f"Project {25}",
+        date_received="2020-01-30",
+    )
+    return project
+
+
+class TestProjectAssociationListing(BaseTest):
+    url = reverse("project-association-list")
+
+    def test_projest_association_listing_permissions(
+        self,
+        _setup_project_list,
+        user,
+        viewer_user,
+        agency_user,
+        agency_inputter_user,
+        secretariat_viewer_user,
+        secretariat_v1_v2_edit_access_user,
+        secretariat_production_v1_v2_edit_access_user,
+        secretariat_v3_edit_access_user,
+        secretariat_production_v3_edit_access_user,
+        admin_user,
+        meta_project,
+    ):
+        agency = AgencyFactory.create(code="Agency1")
+        agency2 = AgencyFactory.create(code="Agency2")
+        project = _setup_project_list
+
+        def _set_project_user_same_agency(user):
+            project.agency = agency
+            project.meta_project = meta_project
+            project.save()
+            user.agency = agency
+            user.save()
+            meta_project.lead_agency = None
+            meta_project.save()
+
+        def _set_project_user_different_agency(
+            user,
+        ):
+            project.agency = agency2
+            project.meta_project = meta_project
+            project.save()
+            user.agency = agency
+            user.save()
+            meta_project.lead_agency = None
+            meta_project.save()
+
+        def _set_project_user_same_lead_agency(user):
+            project.agency = agency2
+            project.meta_project = meta_project
+            project.save()
+            user.agency = agency
+            user.save()
+            meta_project.lead_agency = agency
+            meta_project.save()
+
+        def _test_user_permissions(user, expected_response_status, expected_count=None):
+            self.client.force_authenticate(user=user)
+            response = self.client.get(self.url)
+            assert response.status_code == expected_response_status
+            if expected_count is not None:
+                assert len(response.data) == expected_count
+            return response.data
+
+        # test with unauthenticated user
+        response = self.client.get(self.url)
+        assert response.status_code == 403
+
+        # test with authenticated user
+        self.client.force_authenticate(user=user)
+        response = self.client.get(self.url)
+        assert response.status_code == 403
+
+        # test with viewer user
+        _set_project_user_same_agency(viewer_user)
+        _test_user_permissions(viewer_user, 200, 1)
+        _set_project_user_different_agency(viewer_user)
+        _test_user_permissions(viewer_user, 200, 0)
+        _set_project_user_same_lead_agency(viewer_user)
+        _test_user_permissions(viewer_user, 200, 1)
+
+        # test with agency user
+        _set_project_user_same_agency(agency_user)
+        _test_user_permissions(agency_user, 200, 1)
+        _set_project_user_different_agency(agency_user)
+        _test_user_permissions(agency_user, 200, 0)
+        _set_project_user_same_lead_agency(agency_user)
+        _test_user_permissions(agency_user, 200, 1)
+
+        # test with agency inputter user
+        _set_project_user_same_agency(agency_inputter_user)
+        _test_user_permissions(agency_inputter_user, 200, 1)
+        _set_project_user_different_agency(agency_inputter_user)
+        _test_user_permissions(agency_inputter_user, 200, 0)
+        _set_project_user_same_lead_agency(agency_inputter_user)
+        _test_user_permissions(agency_inputter_user, 200, 1)
+
+        # test with secretariat viewer user
+        _set_project_user_same_agency(secretariat_viewer_user)
+        _test_user_permissions(secretariat_viewer_user, 200, 1)
+        _set_project_user_different_agency(secretariat_viewer_user)
+        _test_user_permissions(secretariat_viewer_user, 200, 1)
+        _set_project_user_same_lead_agency(secretariat_viewer_user)
+        _test_user_permissions(secretariat_viewer_user, 200, 1)
+
+        # test with secretariat v1 v2 edit access user
+        _set_project_user_same_agency(secretariat_v1_v2_edit_access_user)
+        _test_user_permissions(secretariat_v1_v2_edit_access_user, 200, 1)
+        _set_project_user_different_agency(secretariat_v1_v2_edit_access_user)
+        _test_user_permissions(secretariat_v1_v2_edit_access_user, 200, 1)
+        _set_project_user_same_lead_agency(secretariat_v1_v2_edit_access_user)
+        _test_user_permissions(secretariat_v1_v2_edit_access_user, 200, 1)
+
+        # test with secretariat production v1 v2 edit access user
+        _set_project_user_same_agency(secretariat_production_v1_v2_edit_access_user)
+        _test_user_permissions(secretariat_production_v1_v2_edit_access_user, 200, 1)
+        _set_project_user_different_agency(
+            secretariat_production_v1_v2_edit_access_user
+        )
+        _test_user_permissions(secretariat_production_v1_v2_edit_access_user, 200, 1)
+        _set_project_user_same_lead_agency(
+            secretariat_production_v1_v2_edit_access_user
+        )
+        _test_user_permissions(secretariat_production_v1_v2_edit_access_user, 200, 1)
+
+        # test with secretariat v3 edit access user
+        _set_project_user_same_agency(secretariat_v3_edit_access_user)
+        _test_user_permissions(secretariat_v3_edit_access_user, 200, 1)
+        _set_project_user_different_agency(secretariat_v3_edit_access_user)
+        _test_user_permissions(secretariat_v3_edit_access_user, 200, 1)
+        _set_project_user_same_lead_agency(secretariat_v3_edit_access_user)
+        _test_user_permissions(secretariat_v3_edit_access_user, 200, 1)
+
+        # test with secretariat production v3 edit access user
+        _set_project_user_same_agency(secretariat_production_v3_edit_access_user)
+        _test_user_permissions(secretariat_production_v3_edit_access_user, 200, 1)
+        _set_project_user_different_agency(secretariat_production_v3_edit_access_user)
+        _test_user_permissions(secretariat_production_v3_edit_access_user, 200, 1)
+        _set_project_user_same_lead_agency(secretariat_production_v3_edit_access_user)
+        _test_user_permissions(secretariat_production_v3_edit_access_user, 200, 1)
+
+        # test with admin user
+        _set_project_user_same_agency(admin_user)
+        _test_user_permissions(admin_user, 200, 1)
+        _set_project_user_different_agency(admin_user)
+        _test_user_permissions(admin_user, 200, 1)
+        _set_project_user_same_lead_agency(admin_user)
+        _test_user_permissions(admin_user, 200, 1)
+
+    def test_project_association_listing(
+        self,
+        _setup_project_list,
+        secretariat_viewer_user,
+        meta_project,
+        meta_project_mya,
+    ):
+        project1 = _setup_project_list
+        project2 = ProjectFactory.create(
+            title=f"Project {26}",
+            date_received="2020-01-31",
+            agency=project1.agency,
+            meta_project=meta_project_mya,
+        )
+        project1.meta_project = meta_project
+        project1.save()
+
+        self.client.force_authenticate(user=secretariat_viewer_user)
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+        assert len(response.data) == 2
+        assert response.data[0]["code"] == meta_project_mya.code
+        assert response.data[0]["projects"][0]["code"] == project2.code
+        assert response.data[0]["projects"][0]["title"] == project2.title
+        assert response.data[1]["code"] == meta_project.code
+        assert response.data[1]["projects"][0]["code"] == project1.code
+        assert response.data[1]["projects"][0]["title"] == project1.title

--- a/core/api/tests/test_projects_v2.py
+++ b/core/api/tests/test_projects_v2.py
@@ -920,19 +920,83 @@ class TestCreateProjects(BaseTest):
 class TestProjectsV2Update:
     client = APIClient()
 
-    def test_project_patch_anon(self, project_url):
-        response = self.client.patch(project_url, {"title": "Into the Spell"})
-        assert response.status_code == 403
+    def test_update_project_permissions(
+        self,
+        _setup_project_create,
+        user,
+        project,
+        project_url,
+        viewer_user,
+        agency_user,
+        new_agency,
+        agency_inputter_user,
+        secretariat_viewer_user,
+        secretariat_v1_v2_edit_access_user,
+        secretariat_production_v1_v2_edit_access_user,
+        secretariat_v3_edit_access_user,
+        secretariat_production_v3_edit_access_user,
+        admin_user,
+    ):
+        def _test_user_permissions(user, expected_response_status):
+            self.client.force_authenticate(user=user)
+            response = self.client.patch(project_url, {"title": "Into the Spell"})
+            assert response.status_code == expected_response_status, response.data
 
-    def test_as_viewer(self, viewer_user, project_url):
-        self.client.force_authenticate(user=viewer_user)
         response = self.client.patch(project_url, {"title": "Into the Spell"})
-        assert response.status_code == 403
+        assert response.status_code == 403, response.data
 
-    def test_without_permission_wrong_agency(self, other_agency_user, project_url):
-        self.client.force_authenticate(user=other_agency_user)
-        response = self.client.patch(project_url, {"title": "Into the Spell"})
-        assert response.status_code == 404
+        def _test_permissions_for_different_project_agency(
+            user,
+            own_agency_response_status,
+            different_agency_response_status,
+            lead_agency_response_status,
+        ):
+            project.agency = user.agency
+            project.save()
+            _test_user_permissions(user, own_agency_response_status)
+            project.agency = new_agency
+            project.save()
+            project.meta_project.lead_agency = None
+            project.meta_project.save()
+            _test_user_permissions(user, different_agency_response_status)
+            project.meta_project.lead_agency = user.agency
+            project.meta_project.save()
+            _test_user_permissions(user, lead_agency_response_status)
+
+        _test_user_permissions(user, 403)
+        viewer_user.agency = agency_user.agency
+        viewer_user.save()
+        _test_permissions_for_different_project_agency(viewer_user, 403, 403, 403)
+        _test_permissions_for_different_project_agency(agency_user, 200, 404, 200)
+        _test_permissions_for_different_project_agency(
+            agency_inputter_user, 200, 404, 200
+        )
+        secretariat_viewer_user.agency = agency_user.agency
+        secretariat_viewer_user.save()
+        _test_permissions_for_different_project_agency(
+            secretariat_viewer_user, 403, 403, 403
+        )
+        secretariat_v1_v2_edit_access_user.agency = agency_user.agency
+        secretariat_v1_v2_edit_access_user.save()
+        _test_permissions_for_different_project_agency(
+            secretariat_v1_v2_edit_access_user, 200, 200, 200
+        )
+        secretariat_production_v1_v2_edit_access_user.agency = agency_user.agency
+        secretariat_production_v1_v2_edit_access_user.save()
+        _test_permissions_for_different_project_agency(
+            secretariat_production_v1_v2_edit_access_user, 200, 200, 200
+        )
+        secretariat_v3_edit_access_user.agency = agency_user.agency
+        secretariat_v3_edit_access_user.save()
+        _test_permissions_for_different_project_agency(
+            secretariat_v3_edit_access_user, 403, 403, 403
+        )
+        secretariat_production_v3_edit_access_user.agency = agency_user.agency
+        secretariat_production_v3_edit_access_user.save()
+        _test_permissions_for_different_project_agency(
+            secretariat_production_v3_edit_access_user, 403, 403, 403
+        )
+        _test_user_permissions(admin_user, 200)
 
     def test_project_update(self, agency_user, project_url, project):
         self.client.force_authenticate(user=agency_user)
@@ -1691,6 +1755,7 @@ class TestAssociateProject:
         admin_user,
     ):
         url = reverse("project-v2-associate-projects")
+        agency = AgencyFactory.create(code="TESTAG")
 
         def _test_user_permissions(user, expected_response_status):
             self.client.force_authenticate(user=user)
@@ -1698,6 +1763,7 @@ class TestAssociateProject:
                 url,
                 data={
                     "project_ids": [project.id, project2.id],
+                    "lead_agency_id": agency.id,
                 },
                 format="json",
             )
@@ -1728,13 +1794,14 @@ class TestAssociateProject:
     ):
         self.client.force_authenticate(user=secretariat_v1_v2_edit_access_user)
         url = reverse("project-v2-associate-projects")
-
+        agency = AgencyFactory.create(code="TESTAG")
         # associate project
         response = self.client.post(
             url,
             format="json",
             data={
                 "project_ids": [project.id, project2.id],
+                "lead_agency_id": agency.id,
             },
         )
         assert response.status_code == 200, response.data
@@ -1742,6 +1809,7 @@ class TestAssociateProject:
         project.refresh_from_db()
         project2.refresh_from_db()
         assert project.meta_project == project2.meta_project
+        assert project.meta_project.lead_agency == agency
 
         project.meta_project = None
         project.save()
@@ -1753,6 +1821,7 @@ class TestAssociateProject:
             format="json",
             data={
                 "project_ids": [project.id, project2.id],
+                "lead_agency_id": agency.id,
             },
         )
         assert response.status_code == 200, response.data
@@ -1760,3 +1829,4 @@ class TestAssociateProject:
         project.refresh_from_db()
         project2.refresh_from_db()
         assert project.meta_project == project2.meta_project
+        assert project.meta_project.lead_agency == agency

--- a/core/api/urls.py
+++ b/core/api/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path, re_path
+from django.urls import path, re_path, include
 from rest_framework import routers, permissions
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
@@ -114,6 +114,7 @@ from core.api.views.projects_v2 import (
     ProjectFilesDownloadView,
     ProjectFilesValidationView,
 )
+from core.api.views.project_associations import ProjectAssociationViewSet
 from core.api.views.rbm_measures import RBMMeasureListView
 from core.api.views.sector_subsector import ProjectSectorView, ProjectSubSectorView
 from core.api.views.settings import SettingsView
@@ -123,6 +124,9 @@ from core.api.views.countries import CountryListView
 router = routers.SimpleRouter()
 router.register("projects/v2", ProjectV2ViewSet, basename="project-v2")
 router.register("projects", ProjectViewSet, basename="project")
+router.register(
+    "project-association", ProjectAssociationViewSet, basename="project-association"
+)
 router.register("project-fund", ProjectFundViewSet)
 router.register("project-ods-odp", ProjectOdsOdpViewSet)
 router.register("project-comment", ProjectCommentViewSet)

--- a/core/api/urls.py
+++ b/core/api/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path, re_path, include
+from django.urls import path, re_path
 from rest_framework import routers, permissions
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi

--- a/core/api/views/__init__.py
+++ b/core/api/views/__init__.py
@@ -5,6 +5,8 @@ from .cp_archive import *
 from .cp_report_empty_form import *
 from .cp_reports import *
 from .countries import *
+from .project_associations import *
 from .projects import *
+from .projects_v2 import *
 from .replenishment import *
 from .users import *

--- a/core/api/views/project_associations.py
+++ b/core/api/views/project_associations.py
@@ -118,6 +118,3 @@ class ProjectAssociationViewSet(
             "projects__files",
         )
         return queryset
-
-    def list(self, request, *args, **kwargs):
-        return super().list(request, *args, **kwargs)

--- a/core/api/views/project_associations.py
+++ b/core/api/views/project_associations.py
@@ -1,0 +1,123 @@
+from django.db.models import Q
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import mixins, viewsets, filters
+
+from core.api.permissions import (
+    IsAgencyInputter,
+    IsAgencySubmitter,
+    IsSecretariatViewer,
+    IsSecretariatV1V2EditAccess,
+    IsSecretariatV3EditAccess,
+    IsSecretariatProductionV1V2EditAccess,
+    IsSecretariatProductionV3EditAccess,
+    IsViewer,
+)
+from core.api.serializers.project_association import MetaProjectSerializer
+from core.models.project import MetaProject
+from core.models.user import User
+
+# pylint: disable=R1710
+
+
+class ProjectAssociationViewSet(
+    viewsets.GenericViewSet,
+    mixins.ListModelMixin,
+):
+    """ViewSet for listing project associations with meta projects.
+    This viewset allows users to retrieve a list of meta projects and their associated projects.
+    """
+
+    filter_backends = [
+        DjangoFilterBackend,
+        filters.OrderingFilter,
+        filters.SearchFilter,
+    ]
+    ordering_fields = [
+        "lead_agency__name",
+        "type",
+        "projects__title",
+        "projects__country__name",
+        "projects__agency__name",
+        "projects__sector__name",
+        "projects__project_type__name",
+        "projects__substance_type",
+        "projects__submission_status__name",
+        "projects__status__name",
+        "projects__meta_project__code",
+        "projects__code",
+        "projects__cluster__code",
+        "projects__tranche",
+        "projects__total_fund",
+    ]
+    serializer_class = MetaProjectSerializer
+    search_fields = ["projects__title"]
+
+    @property
+    def permission_classes(self):
+        if self.action in ["list"]:
+            return [
+                IsViewer
+                | IsAgencyInputter
+                | IsAgencySubmitter
+                | IsSecretariatViewer
+                | IsSecretariatV1V2EditAccess
+                | IsSecretariatV3EditAccess
+                | IsSecretariatProductionV1V2EditAccess
+                | IsSecretariatProductionV3EditAccess
+            ]
+        return []
+
+    def filter_permissions_queryset(self, queryset):
+        """
+        Filter the queryset based on the user's permissions.
+        """
+        user = self.request.user
+        if user.is_superuser:
+            return queryset
+
+        if user.user_type in [
+            User.UserType.SECRETARIAT_VIEWER,
+            User.UserType.SECRETARIAT_V1_V2_EDIT_ACCESS,
+            User.UserType.SECRETARIAT_V3_EDIT_ACCESS,
+            User.UserType.SECRETARIAT_PRODUCTION_V1_V2_EDIT_ACCESS,
+            User.UserType.SECRETARIAT_PRODUCTION_V3_EDIT_ACCESS,
+        ]:
+            return queryset
+        if user.user_type in [
+            User.UserType.AGENCY_SUBMITTER,
+            User.UserType.AGENCY_INPUTTER,
+            User.UserType.VIEWER,
+        ]:
+            return queryset.filter(
+                Q(projects__agency=user.agency) | Q(lead_agency=user.agency)
+            ).distinct()
+        return queryset.none()
+
+    def get_queryset(self):
+        queryset = MetaProject.objects.all()
+        queryset = self.filter_permissions_queryset(queryset)
+        queryset = queryset.select_related(
+            "lead_agency",
+        ).prefetch_related(
+            "projects__agency",
+            "projects__coop_agencies",
+            "projects__cluster",
+            "projects__country",
+            "projects__rbm_measures__measure",
+            "projects__project_type",
+            "projects__sector",
+            "projects__meeting",
+            "projects__subsectors__sector",
+            "projects__subsectors",
+            "projects__status",
+            "projects__submission_amounts",
+            "projects__submission_status",
+            "projects__ods_odp",
+            "projects__funds",
+            "projects__comments",
+            "projects__files",
+        )
+        return queryset
+
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)

--- a/core/api/views/projects.py
+++ b/core/api/views/projects.py
@@ -32,10 +32,10 @@ from core.api.serializers.project_metadata import (
     ProjectTypeSerializer,
 )
 from core.api.serializers.project import (
-    MetaProjectSerializer,
     ProjectDetailsSerializer,
     ProjectListSerializer,
 )
+from core.api.serializers.project_association import MetaProjectSerializer
 from core.api.views.projects_export import ProjectsExport
 from core.models.meeting import Meeting
 from core.models.project import (

--- a/core/api/views/projects_v2.py
+++ b/core/api/views/projects_v2.py
@@ -34,6 +34,7 @@ from core.api.serializers.project_v2 import (
     ProjectV2CreateUpdateSerializer,
 )
 from core.api.swagger import FileUploadAutoSchema
+from core.models.agency import Agency
 from core.models.project import (
     MetaProject,
     Project,
@@ -197,18 +198,23 @@ class ProjectV2ViewSet(
             queryset = Project.objects.all()
         queryset = self.filter_permissions_queryset(queryset)
         queryset = queryset.select_related(
-            "country",
             "agency",
+            "cluster",
+            "country",
             "project_type",
             "status",
             "submission_status",
-            "cluster",
+            "sector",
             "meeting",
             "meeting_transf",
             "meta_project",
         ).prefetch_related(
             "coop_agencies",
             "submission_amounts",
+            "subsectors",
+            "funds",
+            "comments",
+            "files",
             "subsectors__sector",
             "rbm_measures__measure",
             "ods_odp",
@@ -271,12 +277,6 @@ class ProjectV2ViewSet(
         return Response(
             serializer.data, status=status.HTTP_201_CREATED, headers=headers
         )
-
-    @action(methods=["GET"], detail=False)
-    def api_schema(self, request):
-        meta = self.metadata_class()
-        data = meta.determine_metadata(request, self)
-        return Response(data)
 
     @action(methods=["GET"], detail=False)
     def export(self, *args, **kwargs):
@@ -472,8 +472,12 @@ class ProjectV2ViewSet(
                     type=openapi.TYPE_ARRAY,
                     items=openapi.Items(type=openapi.TYPE_INTEGER),
                 ),
+                "lead_agency_id": openapi.Schema(
+                    type=openapi.TYPE_INTEGER,
+                    description="ID of the lead agency for the meta project.",
+                ),
             },
-            required=["project_ids"],
+            required=["project_ids", "lead_agency_id"],
         ),
         responses={
             status.HTTP_200_OK: ProjectDetailsV2Serializer,
@@ -491,6 +495,15 @@ class ProjectV2ViewSet(
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
+        lead_agency_id = request.data.get("lead_agency_id", None)
+        if not lead_agency_id:
+            return Response(
+                {"error": "Lead agency is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        lead_agency = get_object_or_404(Agency, pk=lead_agency_id)
+
         # Get first meta project that can be found in the project_objs
         meta_project = next(
             (p.meta_project for p in project_objs if p.meta_project), None
@@ -502,6 +515,8 @@ class ProjectV2ViewSet(
 
         # Associate all projects with the meta project
         project_objs.update(meta_project=meta_project)
+        meta_project.lead_agency = lead_agency
+        meta_project.save()
 
         # Clean up any meta projects that have no projects associated with them
 

--- a/core/models/project.py
+++ b/core/models/project.py
@@ -625,10 +625,11 @@ class Project(models.Model):
 
     @property
     def latest_file(self):
-        try:
-            return self.files.latest()
-        except ProjectFile.DoesNotExist:
+        files = list(self.files.all())
+        if not files:
             return None
+        files.sort(key=lambda f: f.date_created, reverse=True)
+        return files[0]
 
 
 class ProjectFile(models.Model):


### PR DESCRIPTION
* Added mandatory field lead_agency_id  to POST `/api/projects/v2/associate_projects/`
* Added endpoint GET `/api/project-association/` that returns a list of metaprojects. Each metaproject contains a field "projects", that lists all the projects that are under that metaproject. Same ordering as for projects listing is available. Filters are due to be implemented.
