### PR TITLE
Add tranche endpoint

### DIFF
--- a/core/api/tests/conftest.py
+++ b/core/api/tests/conftest.py
@@ -471,6 +471,11 @@ def project_submitted_status():
 
 
 @pytest.fixture
+def project_approved_status():
+    return ProjectSubmissionStatusFactory.create(name="Approved", code="approved")
+
+
+@pytest.fixture
 def sector():
     return ProjectSectorFactory.create(name="Sector", code="SEC", sort_order=1)
 

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -126,6 +126,7 @@
 | projects/v2/{id}/                             |  GET    | has_project_v2_view_access     | Entries filtered for 'can_view_only_own_agency'.
 | projects/v2/{id}/                             |  PUT    | has_project_v2_edit_access     | Entries filtered for 'can_view_only_own_agency'.
 | projects/v2/{id}/                             |  PATCH  | has_project_v2_edit_access     | Entries filtered for 'can_view_only_own_agency'.
+| projects/v2/{id}/list_previous_tranches/      |  GET    | has_project_v2_view_access     | Entries filtered for 'can_view_only_own_agency'.
 | projects/v2/{id}/recommend/                   |  POST   | has_project_v2_recommend_projects_access | Entries filtered for 'can_view_only_own_agency'.
 | projects/v2/{id}/recommend/                   |  POST   | has_project_v2_recommend_projects_access |
 | projects/v2/{id}/send_back_to_draft/          |  POST   | has_project_v2_recommend_projects_access |


### PR DESCRIPTION
* Added endpoint `projects/v2/{id}/list_previous_tranches/` that returns a list of the previous tranches for a given project. The previous projects must have the `Approved` submission status, their tranche must be the selected project's tranche - 1 and have the same meta project as the given project's.
* For the same endpoint, the user can also send a query param `projects/v2/{id}/list_previous_tranches/?include_validation=true` to include the errors and warnings for each project. Warnings will be issued for each actual field that does not have a value. An error will be added to the errors list only if not even one actual field has a value.
* The endpoint is available for users with `has_project_v2_view_access` permission