### PR TITLE
Revise projects permissions

### DIFF
--- a/core/api/tests/conftest.py
+++ b/core/api/tests/conftest.py
@@ -83,9 +83,11 @@ def second_user():
 
 
 @pytest.fixture
-def viewer_user():
+def viewer_user(agency):
     group = Group.objects.get(name="Projects - Agency viewer")
-    user = UserFactory(username="GuraCasca", email="doarmauit@numersi.ro")
+    user = UserFactory(
+        username="GuraCasca", email="doarmauit@numersi.ro", agency=agency
+    )
     user.groups.add(group)
     return user
 

--- a/core/api/tests/conftest.py
+++ b/core/api/tests/conftest.py
@@ -218,6 +218,11 @@ def agency_inputter_user(agency):
 
 
 @pytest.fixture
+def new_country():
+    return CountryFactory.create(iso3="NwC")
+
+
+@pytest.fixture
 def country_ro():
     return CountryFactory.create(name="Romania", iso3="ROM")
 
@@ -454,8 +459,18 @@ def project_type():
 
 
 @pytest.fixture
+def new_project_type():
+    return ProjectTypeFactory.create(code="NewType")
+
+
+@pytest.fixture
 def project_status():
     return ProjectStatusFactory.create(name="Project Status", code="PS")
+
+
+@pytest.fixture
+def submitted_status():
+    return ProjectStatusFactory.create(code="NEWSUB")
 
 
 @pytest.fixture
@@ -470,6 +485,11 @@ def project_submitted_status():
     return ProjectSubmissionStatusFactory.create(
         name="Submitted", code="submitted", color="#00FF00"
     )
+
+
+@pytest.fixture
+def new_project_approved_status():
+    return ProjectSubmissionStatusFactory.create(code="approved", name="Approved")
 
 
 @pytest.fixture
@@ -507,6 +527,11 @@ def subsector_other(sector):
 
 
 @pytest.fixture
+def new_sector():
+    return ProjectSectorFactory.create(name="New Sector")
+
+
+@pytest.fixture
 def rbm_measure():
     return RbmMeasureFactory.create(name="RBM Measure", sort_order=1)
 
@@ -514,6 +539,11 @@ def rbm_measure():
 @pytest.fixture
 def meeting():
     return MeetingFactory.create(number=1, date="2019-03-14")
+
+
+@pytest.fixture
+def new_meeting():
+    return MeetingFactory.create(number=3, date="2020-03-14")
 
 
 @pytest.fixture

--- a/core/api/tests/test_projects_v2.py
+++ b/core/api/tests/test_projects_v2.py
@@ -387,6 +387,8 @@ class TestProjectV2List(BaseTest):
 
         # test with authenticated user
         _test_user_permissions(user, 403)
+        viewer_user.agency = None
+        viewer_user.save()
         _test_user_permissions(
             viewer_user, 200, 0
         )  # because user has no agency defined

--- a/core/api/views/project_associations.py
+++ b/core/api/views/project_associations.py
@@ -57,6 +57,9 @@ class ProjectAssociationViewSet(
         if user.is_superuser:
             return queryset
 
+        if not user.has_perm("core.can_view_production_projects"):
+            queryset = queryset.filter(production=False)
+
         if user.has_perm("core.can_view_all_agencies"):
             return queryset
 

--- a/core/api/views/project_v2_export.py
+++ b/core/api/views/project_v2_export.py
@@ -126,8 +126,8 @@ class ProjectsV2ProjectExport:
     wb: openpyxl.Workbook
     project: Project
 
-    def __init__(self, project_id):
-        self.project = Project.objects.get(pk=project_id)
+    def __init__(self, project):
+        self.project = project
         self.setup_workbook()
 
     def setup_workbook(self):

--- a/core/api/views/projects_v2.py
+++ b/core/api/views/projects_v2.py
@@ -32,6 +32,8 @@ from core.api.serializers.project_v2 import (
     ProjectDetailsV2Serializer,
     ProjectListV2Serializer,
     ProjectV2CreateUpdateSerializer,
+    ProjectV2EditActualFieldsSerializer,
+    HISTORY_DESCRIPTION_UPDATE_ACTUAL_FIELDS,
     HISTORY_DESCRIPTION_RECOMMEND_V2,
     HISTORY_DESCRIPTION_SUBMIT_V1,
     HISTORY_DESCRIPTION_WITHDRAW_V3,
@@ -51,6 +53,7 @@ from core.api.views.utils import log_project_history
 from core.api.views.projects_export import ProjectsV2Export
 from core.api.views.project_v2_export import ProjectsV2ProjectExport
 
+# pylint: disable=C0302
 
 class ProjectDestructionTechnologyView(APIView):
     """
@@ -119,6 +122,17 @@ class ProjectV2ViewSet(
 
     search_fields = ["code", "legacy_code", "meta_project__code", "title"]
 
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        # get the queryset for edit permissions to set editable on serializer
+        projects_edit_queryset = self.filter_permissions_queryset(
+            Project.objects.really_all(), results_for_edit=True
+        )
+        context["edit_queryset_ids"] = set(
+            projects_edit_queryset.values_list("id", flat=True)
+        )
+        return context
+
     @property
     def permission_classes(self):
         if self.action in [
@@ -133,6 +147,7 @@ class ProjectV2ViewSet(
             "create",
             "update",
             "partial_update",
+            "edit_actual_fields",
         ]:
             return [HasProjectV2EditAccess]
         if self.action in [
@@ -146,13 +161,36 @@ class ProjectV2ViewSet(
 
         return [DenyAll]
 
-    def filter_permissions_queryset(self, queryset):
+    def filter_permissions_queryset(self, queryset, results_for_edit=False):
         """
         Filter the queryset based on the user's permissions.
         """
         user = self.request.user
         if user.is_superuser:
             return queryset
+
+        if self.action in ["edit_actual_fields"]:
+            queryset.filter(submission_status__name="Approved")
+        if self.action in ["update", "partial_update", "submit"] or results_for_edit:
+            allowed_versions = set()
+            queryset_filters = {}
+
+            if user.has_perm("core.has_project_v2_draft_edit_access"):
+                queryset_filters["submission_status__name"] = "Draft"
+                allowed_versions.update([1, 2])
+            if user.has_perm("core.has_project_v2_version1_version2_edit_access"):
+                queryset_filters.pop("submission_status__name", None)
+                allowed_versions.update([1, 2])
+            if user.has_perm("core.has_project_v2_version3_edit_access"):
+                queryset_filters.pop("submission_status__name", None)
+                allowed_versions.add(3)
+
+            if allowed_versions:
+                queryset_filters["version__in"] = list(allowed_versions)
+            queryset = queryset.filter(**queryset_filters)
+
+        if not user.has_perm("core.can_view_production_projects"):
+            queryset = queryset.filter(production=False)
 
         if user.has_perm("core.can_view_all_agencies"):
             return queryset
@@ -259,7 +297,8 @@ class ProjectV2ViewSet(
         project_id = request.query_params.get("project_id")
 
         if project_id:
-            return ProjectsV2ProjectExport(project_id).export_xls()
+            project = self.get_object()
+            return ProjectsV2ProjectExport(project).export_xls()
         return ProjectsV2Export(self).export_xls()
 
     @action(methods=["POST"], detail=True)
@@ -358,9 +397,6 @@ class ProjectV2ViewSet(
         },
     )
     def recommend(self, request, *args, **kwargs):
-        """
-        This method is not implemented in the V2 API.
-        """
         project = self.get_object()
         serializer = ProjectV2RecommendSerializer(
             project, data=request.data, partial=True
@@ -405,6 +441,34 @@ class ProjectV2ViewSet(
         )
         log_project_history(project, request.user, HISTORY_DESCRIPTION_WITHDRAW_V3)
         project.save()
+        return Response(
+            ProjectDetailsV2Serializer(project).data,
+            status=status.HTTP_200_OK,
+        )
+
+    @action(methods=["PUT"], detail=True)
+    @swagger_auto_schema(
+        operation_description="""
+        Allows editing only the actual fields of the project. Available only for 'Approved' projects.
+        """,
+        request_body=ProjectV2EditActualFieldsSerializer,
+        responses={
+            status.HTTP_200_OK: ProjectDetailsV2Serializer,
+            status.HTTP_400_BAD_REQUEST: "Bad request",
+        },
+    )
+    def edit_actual_fields(self, request, *args, **kwargs):
+        project = self.get_object()
+        serializer = ProjectV2EditActualFieldsSerializer(
+            project, data=request.data, partial=True
+        )
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        serializer.save()
+        log_project_history(
+            project, request.user, HISTORY_DESCRIPTION_UPDATE_ACTUAL_FIELDS
+        )
+
         return Response(
             ProjectDetailsV2Serializer(project).data,
             status=status.HTTP_200_OK,
@@ -470,9 +534,8 @@ class ProjectV2ViewSet(
         },
     )
     def associate_projects(self, request, *args, **kwargs):
-        project_objs = Project.objects.filter(
-            id__in=request.data.get("project_ids", [])
-        )
+        projects = self.filter_permissions_queryset(Project.objects.all())
+        project_objs = projects.filter(id__in=request.data.get("project_ids", []))
 
         if len(project_objs) != len(request.data.get("project_ids", [])):
             return Response(
@@ -768,13 +831,46 @@ class ProjectV2FileView(
             return [HasProjectV2EditAccess]
         return [DenyAll]
 
-    def filter_permissions_queryset(self, queryset):
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        # get the queryset for edit permissions to set editable on serializer
+        projects_edit_queryset = self.filter_permissions_queryset(
+            Project.objects.really_all(), results_for_edit=True
+        )
+
+        edit_queryset = ProjectFile.objects.filter(project__in=projects_edit_queryset)
+        context["edit_queryset_ids"] = set(edit_queryset.values_list("id", flat=True))
+        return context
+
+    def filter_permissions_queryset(self, queryset, results_for_edit=False):
         """
         Filter the queryset based on the user's permissions.
         """
         user = self.request.user
         if user.is_superuser:
             return queryset
+
+        if self.request.method in ["POST", "DELETE"] or results_for_edit:
+
+            allowed_versions = set()
+            queryset_filters = {}
+
+            if user.has_perm("core.has_project_v2_draft_edit_access"):
+                queryset_filters["submission_status__name"] = "Draft"
+                allowed_versions.update([1, 2])
+            if user.has_perm("core.has_project_v2_version1_version2_edit_access"):
+                queryset_filters.pop("submission_status__name", None)
+                allowed_versions.update([1, 2])
+            if user.has_perm("core.has_project_v2_version3_edit_access"):
+                queryset_filters.pop("submission_status__name", None)
+                allowed_versions.add(3)
+
+            if allowed_versions:
+                queryset_filters["version__in"] = list(allowed_versions)
+            queryset = queryset.filter(**queryset_filters)
+
+        if not user.has_perm("core.can_view_production_projects"):
+            queryset = queryset.filter(production=False)
 
         if user.has_perm("core.can_view_all_agencies"):
             return queryset
@@ -783,13 +879,18 @@ class ProjectV2FileView(
             "core.can_view_all_agencies"
         ):
             return queryset.filter(
-                Q(agency=user.agency) | Q(meta_project__lead_agency=user.agency)
+                Q(agency=user.agency)
+                | (
+                    Q(meta_project__lead_agency=user.agency)
+                    & Q(meta_project__lead_agency__isnull=False)
+                )
             )
-
         return queryset.none()
 
-    def get_queryset(self):
-        projects = self.filter_permissions_queryset(Project.objects.really_all())
+    def get_queryset(self, results_for_edit=False):
+        projects = self.filter_permissions_queryset(
+            Project.objects.really_all(), results_for_edit=results_for_edit
+        )
         project = get_object_or_404(projects, pk=self.kwargs.get("project_id"))
         queryset = ProjectFile.objects.filter(project=project)
         return queryset
@@ -900,6 +1001,9 @@ class ProjectFilesDownloadView(generics.RetrieveAPIView):
         if user.is_superuser:
             return queryset
 
+        if not user.has_perm("core.can_view_production_projects"):
+            queryset = queryset.filter(production=False)
+
         if user.has_perm("core.can_view_all_agencies"):
             return queryset
 
@@ -907,7 +1011,11 @@ class ProjectFilesDownloadView(generics.RetrieveAPIView):
             "core.can_view_all_agencies"
         ):
             return queryset.filter(
-                Q(agency=user.agency) | Q(meta_project__lead_agency=user.agency)
+                Q(agency=user.agency)
+                | (
+                    Q(meta_project__lead_agency=user.agency)
+                    & Q(meta_project__lead_agency__isnull=False)
+                )
             )
 
         return queryset.none()

--- a/core/import_data/resources/users/groups.json
+++ b/core/import_data/resources/users/groups.json
@@ -51,6 +51,8 @@
         "permissions": [
             "has_project_metainfo_view_access",
             "can_view_all_agencies",
+            "has_project_v2_draft_edit_access",
+            "has_project_v2_version1_version2_edit_access",
             "has_project_v2_view_access",
             "has_project_v2_edit_access",
             "has_project_v2_submit_access",
@@ -65,6 +67,7 @@
             "has_project_metainfo_view_access",
             "can_view_all_agencies",
             "has_project_v2_view_access",
+            "has_project_v2_version3_edit_access",
             "has_project_v2_associate_projects_access",
             "has_sectors_and_subsectors_view_access"
         ]
@@ -75,8 +78,11 @@
         "permissions": [
             "has_project_metainfo_view_access",
             "can_view_all_agencies",
+            "can_view_production_projects",
             "has_project_v2_view_access",
             "has_project_v2_edit_access",
+            "has_project_v2_draft_edit_access",
+            "has_project_v2_version1_version2_edit_access",
             "has_project_v2_submit_access",
             "has_project_v2_associate_projects_access",
             "has_project_v2_recommend_projects_access",
@@ -88,7 +94,9 @@
         "permissions": [
             "has_project_metainfo_view_access",
             "can_view_all_agencies",
+            "can_view_production_projects",
             "has_project_v2_view_access",
+            "has_project_v2_version3_edit_access",
             "has_project_v2_associate_projects_access",
             "has_sectors_and_subsectors_view_access"
         ]
@@ -101,6 +109,7 @@
             "has_project_statistics_view_access",
             "has_project_v2_view_access",
             "can_view_only_own_agency",
+            "can_view_production_projects",
             "has_project_view_access",
             "can_view_all_agencies_old_project_implementation",
             "has_sectors_and_subsectors_view_access"
@@ -120,8 +129,10 @@
             "has_project_metainfo_view_access",
             "has_project_statistics_view_access",
             "can_view_only_own_agency",
+            "can_view_production_projects",
             "has_project_v2_view_access",
             "has_project_v2_edit_access",
+            "has_project_v2_draft_edit_access",
             "has_project_v2_submit_access",
             "has_project_view_access",
             "has_project_edit_access",
@@ -136,8 +147,10 @@
             "has_project_metainfo_view_access",
             "has_project_statistics_view_access",
             "can_view_only_own_agency",
+            "can_view_production_projects",
             "has_project_v2_view_access",
             "has_project_v2_edit_access",
+            "has_project_v2_draft_edit_access",
             "has_project_view_access",
             "has_project_edit_access",
             "has_sectors_and_subsectors_view_access",
@@ -197,7 +210,11 @@
             "has_sectors_and_subsectors_view_access",
             "has_sectors_and_subsectors_edit_access",
             "can_view_all_agencies",
+            "can_view_production_projects",
             "has_project_v2_submit_access",
+            "has_project_v2_draft_edit_access",
+            "has_project_v2_version1_version2_edit_access",
+            "has_project_v2_version3_edit_access",
             "has_project_v2_associate_projects_access",
             "has_project_v2_recommend_projects_access"
         ]

--- a/core/import_data/resources/users/permissions.json
+++ b/core/import_data/resources/users/permissions.json
@@ -24,6 +24,12 @@
         "model_name": "project"
     },
     {
+        "permission_codename": "can_view_production_projects",
+        "permission_name": "Can view production projects",
+        "app_label": "core",
+        "model_name": "project"
+    },
+    {
         "permission_codename": "can_view_all_agencies_old_project_implementation",
         "permission_name": "Can view entries from all agencies for the old project implementation",
         "app_label": "core",
@@ -110,6 +116,24 @@
     {
         "permission_codename": "has_project_v2_edit_access",
         "permission_name": "Has project v2 edit access",
+        "app_label": "core",
+        "model_name": "project"
+    },
+    {
+        "permission_codename": "has_project_v2_draft_edit_access",
+        "permission_name": "Has project v2 edit access for draft projects",
+        "app_label": "core",
+        "model_name": "project"
+    },
+    {
+        "permission_codename": "has_project_v2_version1_version2_edit_access",
+        "permission_name": "Has project v2 edit access for version 1/version2 projects",
+        "app_label": "core",
+        "model_name": "project"
+    },
+    {
+        "permission_codename": "has_project_v2_version3_edit_access",
+        "permission_name": "Has project v2 edit access for version 3 projects",
         "app_label": "core",
         "model_name": "project"
     },

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -2,17 +2,17 @@
 
 | Endpoint                                      | Method  | Permissions                        | Comments |
 | --------------------------------------------- | --------| ---------------------------------- | ---------|
-| replenishment/countries                       |  GET    |      -                             | Returned entries restricted for 'can_view_only_own_country'|
+| replenishment/countries                       |  GET    |      -                             | Returned entries restricted for `can_view_only_own_country`|
 | replenishment/countries-soa                   |  GET    |      -                             |          |
 | replenishment/as-of-date                      |  GET    | has_replenishment_view_access      |          |
 | replenishment/budget-years                    |  GET    | has_replenishment_view_access      |          |
 | replenishment/replenishments                  |  GET    | has_replenishment_view_access      |          |
 | replenishment/replenishments                  |  POST   | has_replenishment_edit_access      |          |
-| replenishment/disputed-contributions          |  POST   | has_replenishment_edit_access      | Entries filtered for 'can_view_only_own_country' |
-| replenishment/disputed-contributions          |  DELETE | has_replenishment_edit_access      | Entries filtered for 'can_view_only_own_country' |
+| replenishment/disputed-contributions          |  POST   | has_replenishment_edit_access      | Entries filtered for `can_view_only_own_country` |
+| replenishment/disputed-contributions          |  DELETE | has_replenishment_edit_access      | Entries filtered for `can_view_only_own_country` |
 | replenishment/bilateral-assistance            |  POST   | has_replenishment_edit_access      |          |
-| replenishment/bilateral-assistance            |  GET    | has_replenishment_view_access      | Entries filtered for 'can_view_only_own_country' |
-| replenishment/bilateral-assistance/{id}       |  GET    | has_replenishment_view_access      | Entries filtered for 'can_view_only_own_country' |
+| replenishment/bilateral-assistance            |  GET    | has_replenishment_view_access      | Entries filtered for `can_view_only_own_country` |
+| replenishment/bilateral-assistance/{id}       |  GET    | has_replenishment_view_access      | Entries filtered for `can_view_only_own_country` |
 | replenishment/scales-of-assessment            |  GET    | has_replenishment_view_access      |  |
 | replenishment/scales-of-assessment            |  POST   | has_replenishment_edit_access      |  |
 | replenishment/scales-of-assessment/export     |  GET    | has_replenishment_view_access      |  |
@@ -28,15 +28,15 @@
 | /replenishment/external-income/{id}/          |  PUT    | has_replenishment_edit_access      |  |
 | /replenishment/external-income/{id}/          |  PATCH  | has_replenishment_edit_access      |  |
 | /replenishment/external-income/{id}/          |  DELETE | has_replenishment_edit_access      |  |
-| /replenishment/invoices/                      |  GET    | has_replenishment_view_access      | Entries filtered for 'can_view_only_own_country' |
+| /replenishment/invoices/                      |  GET    | has_replenishment_view_access      | Entries filtered for `can_view_only_own_country` |
 | /replenishment/invoices/                      |  POST   | has_replenishment_edit_access      |  |
-| /replenishment/invoices/{id}/                 |  GET    | has_replenishment_view_access      | Entries filtered for 'can_view_only_own_country' |
+| /replenishment/invoices/{id}/                 |  GET    | has_replenishment_view_access      | Entries filtered for `can_view_only_own_country` |
 | /replenishment/invoices/{id}/                 |  PUT    | has_replenishment_edit_access      |  |
 | /replenishment/invoices/{id}/                 |  PATCH  | has_replenishment_edit_access      |  |
 | /replenishment/invoices/{id}/                 |  DELETE | has_replenishment_edit_access      |  |
-| replenishment/payments/                       |  GET    | has_replenishment_view_access      | Entries filtered for 'can_view_only_own_country' |
+| replenishment/payments/                       |  GET    | has_replenishment_view_access      | Entries filtered for `can_view_only_own_country` |
 | replenishment/payments/                       |  POST   | has_replenishment_edit_access      |  |
-| replenishment/payments/{id}/                  |  GET    | has_replenishment_view_access      | Entries filtered for 'can_view_only_own_country' |
+| replenishment/payments/{id}/                  |  GET    | has_replenishment_view_access      | Entries filtered for `can_view_only_own_country` |
 | replenishment/payments/{id}/                  |  PUT    | has_replenishment_edit_access      |  |
 | replenishment/payments/{id}/                  |  PATCH  | has_replenishment_edit_access      |  |
 | replenishment/payments/{id}/                  |  DELETE | has_replenishment_edit_access      |  |
@@ -44,24 +44,24 @@
 | replenishment/status-files/                   |  POST   | has_replenishment_edit_access      |  |
 | replenishment/status-files/{id}/              |  GET    | has_replenishment_view_access      |  |
 | replenishment/status-files/{id}/              |  DELETE | has_replenishment_edit_access      |  |
-| country-programme/reports/                    |  GET    | has_cp_report_view_access          | Entries filtered for 'can_view_only_own_country' |
-| country-programme/reports/                    |  POST   | has_cp_report_edit_access          | Entries filtered for 'can_view_only_own_country'. Need 'can_submit_final_cp_version' for POST with Final status |
-| country-programme/reports/                    |  PUT    | has_cp_report_edit_access          | Need 'can_submit_final_cp_version' for PUT with Final status |
-| country-programme/reports/                    |  PATCH  | has_cp_report_edit_access          | Need 'can_submit_final_cp_version' for PUT with Final status |
+| country-programme/reports/                    |  GET    | has_cp_report_view_access          | Entries filtered for `can_view_only_own_country` |
+| country-programme/reports/                    |  POST   | has_cp_report_edit_access          | Entries filtered for `can_view_only_own_country`. Need `can_submit_final_cp_version` for POST with Final status |
+| country-programme/reports/                    |  PUT    | has_cp_report_edit_access          | Need `can_submit_final_cp_version` for PUT with Final status |
+| country-programme/reports/                    |  PATCH  | has_cp_report_edit_access          | Need `can_submit_final_cp_version` for PUT with Final status |
 | country-programme/reports/                    |  DELETE | has_cp_report_delete_access        |  |
-| country-programme/reports/{id}/               |  GET    | has_cp_report_view_access          | Entries filtered for 'can_view_only_own_country' |
-| country-programme/reports/{id}/               |  POST   | has_cp_report_edit_access          | Entries filtered for 'can_view_only_own_country'. Need 'can_submit_final_cp_version' for POST with Final status |
-| country-programme/reports/{id}/               |  PUT    | has_cp_report_edit_access          | Need 'can_submit_final_cp_version' for PUT with Final status |
-| country-programme/reports/{id}/               |  PATCH  | has_cp_report_edit_access          | Need 'can_submit_final_cp_version' for PUT with Final status |
+| country-programme/reports/{id}/               |  GET    | has_cp_report_view_access          | Entries filtered for `can_view_only_own_country` |
+| country-programme/reports/{id}/               |  POST   | has_cp_report_edit_access          | Entries filtered for `can_view_only_own_country`. Need `can_submit_final_cp_version` for POST with Final status |
+| country-programme/reports/{id}/               |  PUT    | has_cp_report_edit_access          | Need `can_submit_final_cp_version` for PUT with Final status |
+| country-programme/reports/{id}/               |  PATCH  | has_cp_report_edit_access          | Need `can_submit_final_cp_version` for PUT with Final status |
 | country-programme/reports/{id}/               |  DELETE | has_cp_report_delete_access        |  |
-| country-programme/report/{id}/status-update/  |  PUT    | has_cp_report_edit_access          | Entries filtered for 'can_view_only_own_country'. Need 'can_submit_final_cp_version' for POST with Final status |
-| country-programme/report/{id}/comments/       |  POST   | has_cp_report_edit_access          | Need 'can_cp_country_type_comment' for country type comment/'can_cp_secretariat_type_comment' for secretariat comment |
-| country-programme/report/{id}/comments/       |  PUT    | has_cp_report_edit_access          | Need 'can_cp_country_type_comment' for country type comment/'can_cp_secretariat_type_comment' for secretariat comment |
-| country-programme/reports-by-year             |  GET    | has_cp_report_view_access          | Entries filtered for 'can_view_only_own_country' |
-| country-programme/reports-by-country          |  GET    | has_cp_report_view_access          | Entries filtered for 'can_view_only_own_country' |
-| country-programme/records/                    |  GET    | has_cp_report_view_access          | Entries filtered for 'can_view_only_own_country' |
-| country-programme/records/diff/               |  GET    | has_cp_report_view_access          | Entries filtered for 'can_view_only_own_country' |
-| country-programme/export/                     |  GET    | has_cp_report_view_access          | TODO: Check where this ENDPOINT is used.         |
+| country-programme/report/{id}/status-update/  |  PUT    | has_cp_report_edit_access          | Entries filtered for `can_view_only_own_country`. Need `can_submit_final_cp_version` for POST with Final status |
+| country-programme/report/{id}/comments/       |  POST   | has_cp_report_edit_access          | Need `can_cp_country_type_comment` for country type comment/`can_cp_secretariat_type_comment` for secretariat comment |
+| country-programme/report/{id}/comments/       |  PUT    | has_cp_report_edit_access          | Need `can_cp_country_type_comment` for country type comment/`can_cp_secretariat_type_comment` for secretariat comment |
+| country-programme/reports-by-year             |  GET    | has_cp_report_view_access          | Entries filtered for `can_view_only_own_country` |
+| country-programme/reports-by-country          |  GET    | has_cp_report_view_access          | Entries filtered for `can_view_only_own_country` |
+| country-programme/records/                    |  GET    | has_cp_report_view_access          | Entries filtered for `can_view_only_own_country` |
+| country-programme/records/diff/               |  GET    | has_cp_report_view_access          | Entries filtered for `can_view_only_own_country` |
+| country-programme/export/                     |  GET    | has_cp_report_view_access          | TODO: Check where this ENDPOINT is used. |
 | country-programme/reports/export/             |  GET    | has_cp_report_export_access        | |
 | country-programme/hfc/export/                 |  GET    | has_cp_report_export_access        | |
 | country-programme/hcfc/export/                |  GET    | has_cp_report_export_access        | |
@@ -70,29 +70,29 @@
 | country-programme/calculated-amount/print/    |  GET    | has_cp_report_export_access        | |
 | country-programme/export-empty/               |  GET    | has_cp_report_export_access        | |
 | country-programme/print/                      |  GET    | has_cp_report_export_access        | |
-| country-programme/empty-form/                 |  GET    | has_cp_report_export_access        | Entries filtered for 'can_view_only_own_country'. | 
-| country-programme/versions/                   |  GET    | has_cp_report_view_access          | Entries filtered for 'can_view_only_own_country'. |
-| country-programme/files/                      |  GET    | has_cp_report_view_access          | Entries filtered for 'can_view_only_own_country'. |
-| country-programme/files/                      |  POST   | has_cp_report_edit_access          | Country checked  for 'can_view_only_own_country'. |
-| country-programme/files/                      |  DELETE | has_cp_report_edit_access          | Country checked  for 'can_view_only_own_country'. |
+| country-programme/empty-form/                 |  GET    | has_cp_report_export_access        | Entries filtered for `can_view_only_own_country`. | 
+| country-programme/versions/                   |  GET    | has_cp_report_view_access          | Entries filtered for `can_view_only_own_country`. |
+| country-programme/files/                      |  GET    | has_cp_report_view_access          | Entries filtered for `can_view_only_own_country`. |
+| country-programme/files/                      |  POST   | has_cp_report_edit_access          | Country checked  for `can_view_only_own_country`. |
+| country-programme/files/                      |  DELETE | has_cp_report_edit_access          | Country checked  for `can_view_only_own_country`. |
 | country-programme/files/{id}/download/        |  GET    | has_cp_report_view_access          | |
-| country-programme-archive/records/            |  GET    | has_cp_report_view_access          | Entries filtered for 'can_view_only_own_country'. |
-| country-programme-archive/export/             |  GET    | has_cp_report_view_access          | Entries filtered for 'can_view_only_own_country'. |
-| country-programme-archive/print/              |  GET    | has_cp_report_view_access          | Entries filtered for 'can_view_only_own_country'. |
-| countries/                                    |  GET    | -                                  | Entries filtered for 'can_view_only_own_country'. |
+| country-programme-archive/records/            |  GET    | has_cp_report_view_access          | Entries filtered for `can_view_only_own_country`. |
+| country-programme-archive/export/             |  GET    | has_cp_report_view_access          | Entries filtered for `can_view_only_own_country`. |
+| country-programme-archive/print/              |  GET    | has_cp_report_view_access          | Entries filtered for `can_view_only_own_country`. |
+| countries/                                    |  GET    | -                                  | Entries filtered for `can_view_only_own_country`. |
 | meta-projects/                                |  GET    | has_meta_projects_view_access      | |
 | project-statuses/                             |  GET    | has_project_metainfo_view_access   | |
 | project-submission-statuses/                  |  GET    | has_project_metainfo_view_access   | |
 | project-types/                                |  GET    | has_project_metainfo_view_access   | |
-| projects-statistics/                          |  GET    | has_project_statistics_view_access | Entries filtered for 'can_view_only_own_country'. Entries filtered for 'can_view_only_own_agency'.|
+| projects-statistics/                          |  GET    | has_project_statistics_view_access | Entries filtered for `can_view_only_own_country`. Entries filtered for `can_view_only_own_agency`.|
 | project-clusters/                             |  GET    | has_project_metainfo_view_access   | |
 | project-cluster/{cluster_id}/type/{type_id}/sector/{sector_id}/fields/ |  GET    | has_project_metainfo_view_access   | |
 | project-files/{id}/                           |  GET    |                                    | |
 | project-files/{id}/                           |  DELETE |                                    | |
-| project/{project_id}/files/v2/                |  GET    | has_project_v2_view_access         | Entries filtered for 'can_view_only_own_agency'. |
-| project/{project_id}/files/v2/                |  POST   | has_project_v2_edit_access         | Entries filtered for 'can_view_only_own_agency'. |
-| project/{project_id}/files/v2/                |  DELETE | has_project_v2_edit_access         | Entries filtered for 'can_view_only_own_agency'. |
-| project/<int:project_id>/files/<int:id>/download/v2/ |  GET | has_project_v2_view_access     | Entries filtered for 'can_view_only_own_agency'. |
+| project/{project_id}/files/v2/                |  GET    | has_project_v2_view_access         | Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`. `editable` field added for each file to point if the user can or cannot delete the file |
+| project/{project_id}/files/v2/                |  POST   | has_project_v2_edit_access         | Entries filtered for `can_view_only_own_agency`and `can_view_production_projects`. Further filtering using `has_project_v2_draft_edit_access`, `has_project_v2_version1_version2_edit_access` and `has_project_v2_version3_edit_access` (matches editable from GET)
+| project/{project_id}/files/v2/                |  DELETE | has_project_v2_edit_access         |  Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`. Further filtering using `has_project_v2_draft_edit_access`, `has_project_v2_version1_version2_edit_access` and `has_project_v2_version3_edit_access` (matches editable from GET)
+| project/<int:project_id>/files/<int:id>/download/v2/ |  GET | has_project_v2_view_access     |  Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`. |
 | project/files/validate/                       |  POST   | has_project_v2_edit_access         | 
 | business-plan/upload/validate/                |  POST   | has_business_plan_edit_access      | 
 | business-plan/upload/                         |  POST   | has_business_plan_edit_access      | 
@@ -114,33 +114,33 @@
 | replenishment/status-of-contributions/{year}/export/ |  GET    | has_replenishment_view_access  | 
 | replenishment/statistics/export/              |  GET    | has_replenishment_view_access  | 
 | replenishment/status-of-contributions/{year}/ |  GET    | has_replenishment_view_access  | 
-| replenishment/invoice-file/{id}/download/     |  GET    | has_replenishment_view_access  | Entries filtered for 'can_view_only_own_country'. |
-| replenishment/payment-file/{id}/download/     |  GET    | has_replenishment_view_access  | Entries filtered for 'can_view_only_own_country'. |
+| replenishment/invoice-file/{id}/download/     |  GET    | has_replenishment_view_access  | Entries filtered for `can_view_only_own_country`. |
+| replenishment/payment-file/{id}/download/     |  GET    | has_replenishment_view_access  | Entries filtered for `can_view_only_own_country`. |
 | replenishment/scale-of-assessment-version/{id}/file/download/ |  GET    | has_replenishment_view_access  | 
 | replenishment/input-data/export/              |  GET    | has_replenishment_view_access  | 
-| projects/v2/                                  |  GET    | has_project_v2_view_access     | Entries filtered for 'can_view_only_own_agency'.
+| projects/v2/                                  |  GET    | has_project_v2_view_access     | Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`. `editable` field added for each project to point if the user can or cannot edit/submit the project|
 | projects/v2/                                  |  POST   | has_project_v2_edit_access     | 
-| projects/v2/associate_projects/               |  POST   | has_project_v2_associate_projects_access | 
+| projects/v2/associate_projects/               |  POST   | has_project_v2_associate_projects_access | Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`. * `can_view_only_own_agency` will most likely not apply as users with `has_project_v2_associate_projects_access` have access to all agencies.*
 | projects/v2/export/                           |  GET    | has_project_v2_view_access     | 
-| projects/v2/{id}/                             |  GET    | has_project_v2_view_access     | Entries filtered for 'can_view_only_own_agency'.
-| projects/v2/{id}/                             |  PUT    | has_project_v2_edit_access     | Entries filtered for 'can_view_only_own_agency'.
-| projects/v2/{id}/                             |  PATCH  | has_project_v2_edit_access     | Entries filtered for 'can_view_only_own_agency'.
-| projects/v2/{id}/list_previous_tranches/      |  GET    | has_project_v2_view_access     | Entries filtered for 'can_view_only_own_agency'.
-| projects/v2/{id}/list_associated_projects/    |  GET    | has_project_v2_view_access     | Entries filtered for 'can_view_only_own_agency'.
-| projects/v2/{id}/recommend/                   |  POST   | has_project_v2_recommend_projects_access | Entries filtered for 'can_view_only_own_agency'.
-| projects/v2/{id}/recommend/                   |  POST   | has_project_v2_recommend_projects_access |
-| projects/v2/{id}/send_back_to_draft/          |  POST   | has_project_v2_recommend_projects_access |
-| projects/v2/{id}/submit/                      |  POST   | has_project_v2_submit_access   |
-| projects/v2/{id}/withdraw/                    |  POST   | has_project_v2_recommend_projects_access |
-| projects/                                     |  GET    | has_project_view_access                  | Entries filtered for 'can_view_only_own_agency'. Entries filtered for 'can_view_only_own_country' |
-| projects/                                     |  POST   | has_project_edit_access                  | Entries filtered for 'can_view_only_own_agency'. |
+| projects/v2/{id}/                             |  GET    | has_project_v2_view_access     |  Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`. `editable` field added for the project to point if the user can or cannot edit/submit the project|
+| projects/v2/{id}/                             |  PUT    | has_project_v2_edit_access     |  Entries filtered for 'can_view_only_own_agency' and `can_view_production_projects`.  Further filtering using `has_project_v2_draft_edit_access`, `has_project_v2_version1_version2_edit_access` and `has_project_v2_version3_edit_access` (matches editable from GET)
+| projects/v2/{id}/edit_actual_fields/          |  PUT    | has_project_v2_edit_access     |  Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`. Only allowed for projects with submission status = `Appproved`
+| projects/v2/{id}/                             |  PATCH  | has_project_v2_edit_access     | Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`.  Further filtering using `has_project_v2_draft_edit_access`, `has_project_v2_version1_version2_edit_access` and `has_project_v2_version3_edit_access` (matches editable from GET)
+| projects/v2/{id}/list_previous_tranches/      |  GET    | has_project_v2_view_access     | Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`. *only given project is filtered, all tranches are returned*
+| projects/v2/{id}/list_associated_projects/    |  GET    | has_project_v2_view_access     | Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`. *only given project is filtred, all associated projects are not.
+| projects/v2/{id}/recommend/                   |  POST   | has_project_v2_recommend_projects_access | Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`.
+| projects/v2/{id}/send_back_to_draft/          |  POST   | has_project_v2_recommend_projects_access |  Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`.
+| projects/v2/{id}/submit/                      |  POST   | has_project_v2_submit_access   | Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`.  Further filtering using `has_project_v2_draft_edit_access`, `has_project_v2_version1_version2_edit_access` and `has_project_v2_version3_edit_access` (matches editable from GET). ! Just the given project is filtered, associated/previous tranches don't have permissions over them.
+| projects/v2/{id}/withdraw/                    |  POST   | has_project_v2_recommend_projects_access |  Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`.
+| projects/                                     |  GET    | has_project_view_access                  | Entries filtered for `can_view_only_own_agency`. Entries filtered for `can_view_only_own_country` |
+| projects/                                     |  POST   | has_project_edit_access                  | Entries filtered for `can_view_only_own_agency`. |
 | projects/export/                              |  GET    | has_project_view_access                  | |
 | projects/print/                               |  GET    | has_project_view_access                  | |
-| projects/{id}/                                |  GET    | has_project_view_access                  | Entries filtered for 'can_view_only_own_agency'. Entries filtered for 'can_view_only_own_country' |
-| projects/{id}/                                |  PUT    | has_project_edit_access                  | Entries filtered for 'can_view_only_own_agency'. |
-| projects/{id}/                                |  PATCH  | has_project_edit_access                  | Entries filtered for 'can_view_only_own_agency'. |
+| projects/{id}/                                |  GET    | has_project_view_access                  | Entries filtered for `can_view_only_own_agency`. Entries filtered for `can_view_only_own_country` |
+| projects/{id}/                                |  PUT    | has_project_edit_access                  | Entries filtered for `can_view_only_own_agency`. |
+| projects/{id}/                                |  PATCH  | has_project_edit_access                  | Entries filtered for `can_view_only_own_agency`. |
 | projects/{id}/upload/                         |  POST   | has_project_edit_access                  | |
-| project-association/                          |  GET    | has_project_v2_view_access               | Entries filtered for 'can_view_only_own_agency'. |
+| project-association/                          |  GET    | has_project_v2_view_access               | Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`. |
 | project-fund/                                 |  POST   | has_project_edit_access                  | |
 | project-fund/                                 |  PUT    | has_project_edit_access                  | |
 | project-fund/                                 |  PATCH  | has_project_edit_access                  | |


### PR DESCRIPTION
To update permissions run:

    python manage.py import_user_permissions import_permissions
    python manage.py import_user_permissions import_user_groups

* Filtered `project/{project_id}/files/v2/` `GET` further using `can_view_only_own_agency` and `can_view_production_projects` . On `GET`, added `editable` field for each file to point if the user can or cannot delete the file. `POST` should be determined from the `editable` from project.
* `project/{project_id}/files/v2/` `POST` `DELETE` - objects that can be edited are filtered using `has_project_v2_draft_edit_access`, `has_project_v2_version1_version2_edit_access` and `has_project_v2_version3_edit_access` (matches editable from GET)
* Filtered `project/<int:project_id>/files/<int:id>/download/v2/` `GET` -  Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`. 
* Filtered `projects/v2/` `GET` - Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`. `editable` field added for each project to point if the user can or cannot edit/submit the project
* Filtered `projects/v2/` `POST` - Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`.    
* Filtered ` projects/v2/associate_projects/` `POST` -  Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`. 
       - `can_view_only_own_agency` will most likely not apply as users with `has_project_v2_associate_projects_access` have access to all agencies.
* Filtered `projects/v2/{id}/` `GET` - Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`. `editable` field added for the project to point if the user can or cannot edit/submit the project
* Filtered `projects/v2/{id}/` `PUT` `PATCH` -  Entries filtered for 'can_view_only_own_agency' and `can_view_production_projects`.  Further filtering using `has_project_v2_draft_edit_access`, `has_project_v2_version1_version2_edit_access` and `has_project_v2_version3_edit_access` (matches editable from GET)

-------
* `projects/v2/{id}/list_previous_tranches/` `GET` - Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`. *only given project is filtered, all tranches are returned*
* `projects/v2/{id}/list_associated_projects/` `GET` - Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`. *only given project is filtred, all associated projects are not.
* `project-association` `GET` - Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`.
------
* `projects/v2/{id}/recommend/` `POST` - Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`.
* `projects/v2/{id}/send_back_to_draft/` `POST` - Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`.
* `projects/v2/{id}/submit/` `POST` - Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`.  Further filtering using `has_project_v2_draft_edit_access`, `has_project_v2_version1_version2_edit_access` and `has_project_v2_version3_edit_access` (matches editable from GET). ! Just the given project is filtered, associated/previous tranches don't have permissions over them.
* `projects/v2/{id}/withdraw/` `POST` - Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`.
-------
* Added endpoint `projects/v2/{id}/edit_actual_fields/` `PUT` to be used for previous_tranches, as Agency can't usually edit V3 projects - Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`. Only allowed for projects with submission status = `Approved`


