### PR TITLE
Submit only components

### DIFF
--- a/core/api/tests/factories.py
+++ b/core/api/tests/factories.py
@@ -2,6 +2,7 @@ import factory.fuzzy
 from django.contrib.auth import get_user_model
 
 from core.models import (
+    ProjectComponents,
     Replenishment,
     ScaleOfAssessment,
     AnnualContributionStatus,
@@ -387,6 +388,11 @@ class DecisionFactory(factory.django.DjangoModelFactory):
     meeting = factory.SubFactory(MeetingFactory)
     number = factory.Faker("random_int", min=1, max=100)
     description = factory.Faker("pystr", max_chars=100)
+
+
+class ProjectComponentsFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = ProjectComponents
 
 
 class ProjectClusterFactory(factory.django.DjangoModelFactory):

--- a/core/api/tests/projects/test_projects_v2_submission.py
+++ b/core/api/tests/projects/test_projects_v2_submission.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from rest_framework.test import APIClient
 
 from core.api.tests.factories import (
+    ProjectComponentsFactory,
     ProjectFieldFactory,
     ProjectSpecificFieldsFactory,
 )
@@ -137,12 +138,14 @@ class TestProjectVersioning:
         url = reverse("project-v2-submit", args=(project2.id,))
 
         # setup projects for submission
+
         project2.submission_status = project_draft_status
+        project2.component = ProjectComponentsFactory()
         project2.save()
         project.submission_status = project_draft_status
         project.meta_project = project2.meta_project
-        project.save()
         project.tranche = 2
+        project.component = project2.component
         project.save()
         project3.submission_status = project_approved_status
         project3.tranche = 1

--- a/core/import_data/resources/projects_v2/Fields_06_05_2025.json
+++ b/core/import_data/resources/projects_v2/Fields_06_05_2025.json
@@ -1004,8 +1004,8 @@
         "SECTION": "Impact",
         "IS_ACTUAL": true,
         "SORT_ORDER": 80,
-        "EDITABLE_IN_VERSIONS": [1,2,3],
-        "VISIBLE_IN_VERSIONS": [1,2,3]
+        "EDITABLE_IN_VERSIONS": [3],
+        "VISIBLE_IN_VERSIONS": [3]
     },
     {
         "IMPORT_NAME": "MEPS developed for commercial AC (yes/no)",


### PR DESCRIPTION
* Added query param __only_components__ to _api/projects/v2/{id}/list_associated_projects/_ . When used, it lists only the components of the project.
* Modified _submit_ to only submit the project and its components
* Fixed permissions on fields. Run `python manage.py import_resources_v2 all` to update fields:

