### PR TITLE
Add project settings endpoint

### DIFF
--- a/core/api/permissions.py
+++ b/core/api/permissions.py
@@ -111,6 +111,14 @@ class HasProjectV2EditAccess(permissions.BasePermission):
         return request.user.has_perm("core.has_project_v2_edit_access")
 
 
+class HasProjectSettingsAccess(permissions.BasePermission):
+    def has_permission(self, request, view):
+        """
+        Check if the user has permission to view and edit project settings.
+        """
+        return request.user.has_perm("core.has_project_settings_access")
+
+
 class HasProjectViewAccess(permissions.BasePermission):
     def has_permission(self, request, view):
         """

--- a/core/api/tests/test_settings.py
+++ b/core/api/tests/test_settings.py
@@ -6,7 +6,7 @@ from core.api.tests.base import BaseTest
 
 
 pytestmark = pytest.mark.django_db
-# pylint: disable=C8008
+# pylint: disable=C8008,R0913
 
 
 class TestSettings(BaseTest):

--- a/core/api/tests/test_settings.py
+++ b/core/api/tests/test_settings.py
@@ -33,3 +33,74 @@ class TestSettings(BaseTest):
         assert set(config.CP_NOTIFICATION_EMAILS) == set(
             ["test@ors.org", "test2@ors.org"]
         )
+
+
+class TestProjectSettings(BaseTest):
+    url = reverse("project-settings")
+
+    def test_permissions(
+        self,
+        user,
+        viewer_user,
+        agency_user,
+        agency_inputter_user,
+        secretariat_viewer_user,
+        secretariat_v1_v2_edit_access_user,
+        secretariat_production_v1_v2_edit_access_user,
+        secretariat_v3_edit_access_user,
+        secretariat_production_v3_edit_access_user,
+        mlfs_admin_user,
+        admin_user,
+    ):
+        def _test_user_permissions(
+            user, expected_get_response_status, expected_post_response_status
+        ):
+            self.client.force_authenticate(user=user)
+            response = self.client.get(self.url)
+            assert response.status_code == expected_get_response_status
+            response = self.client.post(self.url, {})
+            assert response.status_code == expected_post_response_status
+
+        _test_user_permissions(user, 403, 403)
+        _test_user_permissions(viewer_user, 403, 403)
+        _test_user_permissions(agency_user, 403, 403)
+        _test_user_permissions(agency_inputter_user, 403, 403)
+        _test_user_permissions(secretariat_viewer_user, 403, 403)
+        _test_user_permissions(secretariat_v1_v2_edit_access_user, 403, 403)
+        _test_user_permissions(secretariat_production_v1_v2_edit_access_user, 403, 403)
+        _test_user_permissions(secretariat_v3_edit_access_user, 403, 403)
+        _test_user_permissions(secretariat_production_v3_edit_access_user, 403, 403)
+        _test_user_permissions(mlfs_admin_user, 200, 200)
+        _test_user_permissions(admin_user, 200, 200)
+
+    def test_get_settings(self, mlfs_admin_user):
+        self.client.force_authenticate(user=mlfs_admin_user)
+
+        response = self.client.get(self.url)
+        assert response.status_code == 200
+
+    def test_update_settings(self, mlfs_admin_user):
+        self.client.force_authenticate(user=mlfs_admin_user)
+        assert config.PROJECT_SUBMISSION_NOTIFICATIONS_ENABLED is False
+        assert config.PROJECT_SUBMISSION_NOTIFICATIONS_EMAILS == ""
+        assert config.PROJECT_RECOMMENDATION_NOTIFICATIONS_ENABLED is False
+        assert config.PROJECT_RECOMMENDATION_NOTIFICATIONS_EMAILS == ""
+
+        data = {
+            "project_submission_notifications_enabled": True,
+            "project_submission_notifications_emails": "test@ors.org,test2@ors.org",
+            "project_recommendation_notifications_enabled": True,
+            "project_recommendation_notifications_emails": "test2@ors.org,test3@ors.org",
+        }
+        response = self.client.post(self.url, data, format="json")
+        assert response.status_code == 200
+        assert config.PROJECT_SUBMISSION_NOTIFICATIONS_ENABLED is True
+        assert config.PROJECT_RECOMMENDATION_NOTIFICATIONS_ENABLED is True
+        assert (
+            config.PROJECT_SUBMISSION_NOTIFICATIONS_EMAILS
+            == "test@ors.org,test2@ors.org"
+        )
+        assert (
+            config.PROJECT_RECOMMENDATION_NOTIFICATIONS_EMAILS
+            == "test2@ors.org,test3@ors.org"
+        )

--- a/core/api/urls.py
+++ b/core/api/urls.py
@@ -122,7 +122,7 @@ from core.api.views.projects_v2 import (
 from core.api.views.project_associations import ProjectAssociationViewSet
 from core.api.views.rbm_measures import RBMMeasureListView
 from core.api.views.sector_subsector import ProjectSectorView, ProjectSubSectorView
-from core.api.views.settings import SettingsView
+from core.api.views.settings import ProjectSettingsView, SettingsView
 from core.api.views.usages import UsageListView
 from core.api.views.countries import CountryListView, BusinessPlanCountryListView
 
@@ -232,6 +232,11 @@ urlpatterns = [
         "settings/",
         SettingsView.as_view(),
         name="settings",
+    ),
+    path(
+        "project-settings/",
+        ProjectSettingsView.as_view(),
+        name="project-settings",
     ),
     path(
         "agencies/",

--- a/core/api/views/projects_v2.py
+++ b/core/api/views/projects_v2.py
@@ -439,7 +439,7 @@ class ProjectV2ViewSet(
                     associated_project, request.user, HISTORY_DESCRIPTION_SUBMIT_V1
                 )
         # Send email notification to the secretariat team
-        if config.SEND_MAIL:
+        if config.PROJECT_SUBMISSION_NOTIFICATIONS_ENABLED:
             send_project_submission_notification.delay(
                 [project.id for project in associated_projects]
             )

--- a/core/api/views/settings.py
+++ b/core/api/views/settings.py
@@ -4,6 +4,9 @@ from django.db.models import Min
 from rest_framework import status, views
 from rest_framework.response import Response
 
+from core.api.permissions import (
+    HasProjectSettingsAccess,
+)
 from core.api.utils import PROJECT_SECTOR_TYPE_MAPPING
 from core.models import CPReport
 from core.models.blend import Blend
@@ -59,7 +62,6 @@ class SettingsView(views.APIView):
             },
             "send_mail": config.SEND_MAIL,
             "cp_notification_emails": ",".join(config.CP_NOTIFICATION_EMAILS),
-            "project_submission_notification_emails": config.PROJECT_SUBMISSION_NOTIFICATION_EMAILS,
         }
         return Response(settings)
 
@@ -84,6 +86,46 @@ class SettingsView(views.APIView):
             {
                 "send_mail": config.SEND_MAIL,
                 "cp_notification_emails": ",".join(config.CP_NOTIFICATION_EMAILS),
+            },
+            status=status.HTTP_200_OK,
+        )
+
+
+class ProjectSettingsView(views.APIView):
+    """
+    API endpoint that allows project settings to be viewed and edited.
+    """
+
+    permission_classes = [HasProjectSettingsAccess]
+
+    def get(self, *args, **kwargs):
+        settings = {
+            "project_submission_notifications_enabled": config.PROJECT_SUBMISSION_NOTIFICATIONS_ENABLED,
+            "project_submission_notifications_emails": config.PROJECT_SUBMISSION_NOTIFICATIONS_EMAILS,
+            "project_recommendation_notifications_enabled": config.PROJECT_RECOMMENDATION_NOTIFICATIONS_ENABLED,
+            "project_recommendation_notifications_emails": config.PROJECT_RECOMMENDATION_NOTIFICATIONS_EMAILS,
+        }
+        return Response(settings)
+
+    def post(self, request, *args, **kwargs):
+        config.PROJECT_SUBMISSION_NOTIFICATIONS_EMAILS = request.data.get(
+            "project_submission_notifications_emails", ""
+        )
+        config.PROJECT_SUBMISSION_NOTIFICATIONS_ENABLED = request.data.get(
+            "project_submission_notifications_enabled", False
+        )
+        config.PROJECT_RECOMMENDATION_NOTIFICATIONS_ENABLED = request.data.get(
+            "project_recommendation_notifications_enabled", False
+        )
+        config.PROJECT_RECOMMENDATION_NOTIFICATIONS_EMAILS = request.data.get(
+            "project_recommendation_notifications_emails", ""
+        )
+        return Response(
+            {
+                "project_submission_notifications_emails": config.PROJECT_SUBMISSION_NOTIFICATIONS_EMAILS,
+                "project_submission_notifications_enabled": config.PROJECT_SUBMISSION_NOTIFICATIONS_ENABLED,
+                "project_recommendation_notifications_enabled": config.PROJECT_RECOMMENDATION_NOTIFICATIONS_ENABLED,
+                "project_recommendation_notifications_emails": config.PROJECT_RECOMMENDATION_NOTIFICATIONS_EMAILS,
             },
             status=status.HTTP_200_OK,
         )

--- a/core/api/views/utils.py
+++ b/core/api/views/utils.py
@@ -1057,9 +1057,7 @@ class StatisticsStatusOfContributionsAggregator:
                         year__lte=models.OuterRef("end_year"),
                     )
                     # Group by replenishment start year
-                    .annotate(
-                        start_year_replenishment=models.OuterRef("start_year")
-                    )
+                    .annotate(start_year_replenishment=models.OuterRef("start_year"))
                     .values("start_year_replenishment")
                     .annotate(total=models.Sum("amount"))
                     .values("total")[:1]

--- a/core/import_data/import_project_resources_v2.py
+++ b/core/import_data/import_project_resources_v2.py
@@ -208,7 +208,9 @@ def import_project_type(file_path):
                 "name": type_json["TYPE_PRO"],
                 "sort_order": type_json["SORT_TYPE"],
             }
-            ProjectType.objects.update_or_create(name=type_data["name"], defaults=type_data)
+            ProjectType.objects.update_or_create(
+                name=type_data["name"], defaults=type_data
+            )
 
 
 def import_sector(file_path):

--- a/core/import_data/resources/users/groups.json
+++ b/core/import_data/resources/users/groups.json
@@ -220,7 +220,8 @@
             "has_project_v2_version3_edit_access",
             "has_project_v2_approve_projects_access",
             "has_project_v2_associate_projects_access",
-            "has_project_v2_recommend_projects_access"
+            "has_project_v2_recommend_projects_access",
+            "has_project_settings_access"
         ]
     }
 ]

--- a/core/import_data/resources/users/permissions.json
+++ b/core/import_data/resources/users/permissions.json
@@ -180,6 +180,12 @@
         "model_name": "project"
     },
     {
+        "permission_codename": "has_project_settings_access",
+        "permission_name": "Has project settings view and edit access",
+        "app_label": "core",
+        "model_name": "project"
+    },
+    {
         "permission_codename": "has_business_plan_view_access",
         "permission_name": "Has business plan view access",
         "app_label": "core",

--- a/core/models/project.py
+++ b/core/models/project.py
@@ -788,6 +788,9 @@ class Project(models.Model):
 
             old_project.save()
 
+            # set subsectors M2M field
+            old_project.subsectors.set(self.subsectors.all())
+
             self.version += 1
             self.version_created_by = user
             self.save()

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -31,7 +31,7 @@ User = get_user_model()
 def send_project_submission_notification(project_ids):
     projects = Project.objects.filter(id__in=project_ids)
 
-    recipients = config.PROJECT_SUBMISSION_NOTIFICATION_EMAILS
+    recipients = config.PROJECT_SUBMISSION_NOTIFICATIONS_EMAILS
     if isinstance(recipients, str):
         recipients = recipients.split(",")
     if not recipients:

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -136,6 +136,8 @@
 | projects/v2/{id}/withdraw/                    |  POST   | has_project_v2_recommend_projects_access |  Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`.
 | projects/v2/{id}/reject/                      |  POST   | has_project_v2_approve_projects_access   |  Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`.
 | projects/v2/{id}/approve/                     |  POST   | has_project_v2_approve_projects_access   |  Entries filtered for `can_view_only_own_agency` and `can_view_production_projects`.
+| project-settings/                             |  GET    | has_project_settings_access              | |
+| project-settings/                             |  POST   | has_project_settings_access              | |
 | projects/                                     |  GET    | has_project_view_access                  | Entries filtered for `can_view_only_own_agency`. Entries filtered for `can_view_only_own_country` |
 | projects/                                     |  POST   | has_project_edit_access                  | Entries filtered for `can_view_only_own_agency`. |
 | projects/export/                              |  GET    | has_project_view_access                  | |

--- a/frontend/src/@types/store.d.ts
+++ b/frontend/src/@types/store.d.ts
@@ -164,6 +164,8 @@ export interface ProjectsSlice {
   statuses: SliceData<ProjectStatusType[]>
   submission_statuses: SliceData<ProjectSubmissionStatusType[]>
   subsectors: SliceData<ProjectSubSectorType[]>
+  setProjectSettings: (newProjectSettings: Partial<Settings>) => void
+  project_settings: SliceData<Settings>
   types: SliceData<ProjectTypeType[]>
   substances_groups: SliceData<ProjectSubstancesGroupsType[]>
 }
@@ -324,8 +326,10 @@ export type Settings = {
   business_plan_activity_statuses: [string, string][]
   business_plan_statuses: [string, string][]
   cp_notification_emails: string
-  project_submission_notification_emails: string
-  project_recommendation_notification_emails: string
+  project_submission_notifications_enabled: boolean
+  project_submission_notifications_emails: string
+  project_recommendation_notifications_enabled: boolean
+  project_recommendation_notifications_emails: string
   cp_reports: {
     max_year: number
     min_year: number
@@ -336,8 +340,6 @@ export type Settings = {
   project_submission_categories: [string, string][]
   project_substance_types: [string, string][]
   send_mail: boolean
-  send_submission_email: boolean
-  send_recommendation_email: boolean
   submission_amount_statuses: [string, string][]
   year_section_mapping: { max_year: number; sections: string[] }[]
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -58,6 +58,7 @@ function useAppState(user: ApiUser | null | undefined) {
         const [
           // Common data
           settings,
+          project_settings,
           user_permissions,
           agencies,
           countries,
@@ -76,6 +77,7 @@ function useAppState(user: ApiUser | null | undefined) {
           substances,
         ] = await Promise.all([
           api('api/settings/', {}, false),
+          api('api/project-settings/', {}, false),
           api('api/user/permissions/', {}, false),
           api('api/agencies/', {}, false),
           api('api/countries/', {}, false),
@@ -116,6 +118,7 @@ function useAppState(user: ApiUser | null | undefined) {
         const projects = {
           clusters: getInitialSliceData(clusters),
           meetings: getInitialSliceData(meetings),
+          project_settings: getInitialSliceData(project_settings),
           sectors: getInitialSliceData<ProjectSectorType[]>(sectors),
           statuses: getInitialSliceData<ProjectStatusType[]>(statuses),
           submission_statuses:

--- a/frontend/src/app/projects_listing/settings/page.tsx
+++ b/frontend/src/app/projects_listing/settings/page.tsx
@@ -10,12 +10,11 @@ import usePageTitle from '@ors/hooks/usePageTitle'
 import { Redirect } from 'wouter'
 
 export default function ProjectsSettingsWrapper() {
-  usePageTitle('Settings')
+  usePageTitle('Project settings')
 
-  const { canSubmitProjects, canRecommendProjects } =
-    useContext(PermissionsContext)
+  const { canSetProjectSettings } = useContext(PermissionsContext)
 
-  if (!(canSubmitProjects || canRecommendProjects)) {
+  if (!canSetProjectSettings) {
     return <Redirect to="/projects-listing/listing" />
   }
 

--- a/frontend/src/components/manage/Blocks/ProjectsListing/ProjectView/ProjectViewWrapper.tsx
+++ b/frontend/src/components/manage/Blocks/ProjectsListing/ProjectView/ProjectViewWrapper.tsx
@@ -4,7 +4,6 @@ import { useContext, useEffect, useState } from 'react'
 
 import HeaderTitle from '@ors/components/theme/Header/HeaderTitle'
 import Loading from '@ors/components/theme/Loading/Loading'
-import NotFound from '@ors/components/theme/Views/NotFound'
 import CustomLink from '@ors/components/ui/Link/Link'
 import { PageHeading } from '@ors/components/ui/Heading/Heading'
 import PermissionsContext from '@ors/contexts/PermissionsContext'
@@ -62,7 +61,7 @@ const ProjectViewWrapper = () => {
   }, [cluster_id, project_type_id, sector_id])
 
   if (project?.error) {
-    return <NotFound />
+    return <Redirect to="/projects-listing/listing" />
   }
 
   if (data && latest_project && !location.includes('archive')) {

--- a/frontend/src/components/manage/Blocks/ProjectsListing/ProjectsListing/PListingTable.tsx
+++ b/frontend/src/components/manage/Blocks/ProjectsListing/ProjectsListing/PListingTable.tsx
@@ -112,6 +112,10 @@ const PListingTable = ({
                     ? 'meta_project__code'
                     : colId.split('.')[0] + '__name'
 
+              if (colId === 'code') {
+                // Ordering by code needs to be sent as 'filtered_code'
+                return (sort === 'asc' ? '' : '-') + 'filtered_code'
+              }
               return (sort === 'asc' ? '' : '-') + field
             })
             .join(',')

--- a/frontend/src/components/manage/Blocks/ProjectsListing/ProjectsListing/schema.tsx
+++ b/frontend/src/components/manage/Blocks/ProjectsListing/ProjectsListing/schema.tsx
@@ -91,13 +91,15 @@ const getColumnDefs = (
           <div className="flex items-center gap-1 p-2">
             {mode !== 'association' && (
               <>
-                {canEditProjects && props.data.editable && (
+                {canEditProjects && props.data.editable ? (
                   <Link
                     className="flex h-4 w-4 justify-center"
                     href={`/projects-listing/${props.data.id}/edit`}
                   >
                     <FiEdit size={16} />
                   </Link>
+                ) : (
+                  <div className="w-4" />
                 )}
                 {projectId !== undefined &&
                   setProjectData &&

--- a/frontend/src/components/manage/Blocks/ProjectsListing/ProjectsSettings/ProjectsSettings.tsx
+++ b/frontend/src/components/manage/Blocks/ProjectsListing/ProjectsSettings/ProjectsSettings.tsx
@@ -29,18 +29,17 @@ type SetEmailSettingsType = Dispatch<SetStateAction<EmailSettingsType>>
 
 const ProjectsSettings = () => {
   const { enqueueSnackbar } = useSnackbar()
-  const { settings, setSettings } = useStore((state) => state.common)
-
+  const { setProjectSettings, project_settings } = useStore((state) => state.projects)
   const [submissionEmail, setSubmissionEmail] = useState<EmailSettingsType>({
-    withNotifications: settings.data?.send_submission_email || false,
-    emailAddresses: settings.data?.project_submission_notification_emails || '',
+    withNotifications: project_settings.data?.project_submission_notifications_enabled || false,
+    emailAddresses: project_settings.data?.project_submission_notifications_emails || '',
     errors: null,
   })
   const [recommendationEmail, setRecommendationEmail] =
     useState<EmailSettingsType>({
-      withNotifications: settings.data?.send_recommendation_email || false,
+      withNotifications: project_settings.data?.project_recommendation_notifications_enabled || false,
       emailAddresses:
-        settings.data?.project_recommendation_notification_emails || '',
+        project_settings.data?.project_recommendation_notifications_emails || '',
       errors: null,
     })
 
@@ -51,8 +50,8 @@ const ProjectsSettings = () => {
         emailSettings: submissionEmail,
         setEmailSettings: setSubmissionEmail,
         fieldsForUpdate: {
-          send_email: 'send_submission_email',
-          notification_emails: 'project_submission_notification_emails',
+          send_email: 'project_submission_notifications_enabled',
+          notification_emails: 'project_submission_notifications_emails',
         },
       },
       {
@@ -60,8 +59,8 @@ const ProjectsSettings = () => {
         emailSettings: recommendationEmail,
         setEmailSettings: setRecommendationEmail,
         fieldsForUpdate: {
-          send_email: 'send_recommendation_email',
-          notification_emails: 'project_recommendation_notification_emails',
+          send_email: 'project_recommendation_notifications_enabled',
+          notification_emails: 'project_recommendation_notifications_emails',
         },
       },
     ],
@@ -75,11 +74,11 @@ const ProjectsSettings = () => {
   ) => {
     try {
       const newSettings = {
-        ...settings.data,
+        ...project_settings.data,
         [field]: event.target.checked,
       }
 
-      await api(`api/settings`, {
+      await api(`api/project-settings`, {
         data: newSettings,
         method: 'POST',
       })
@@ -89,7 +88,7 @@ const ProjectsSettings = () => {
         withNotifications: newSettings[field as keyof Settings] as boolean,
         errors: null,
       }))
-      setSettings({
+      setProjectSettings({
         // @ts-ignore
         data: newSettings,
       })
@@ -127,11 +126,11 @@ const ProjectsSettings = () => {
   ) => {
     try {
       const newSettings = {
-        ...settings.data,
+        ...project_settings.data,
         [field]: emailAddresses,
       }
 
-      await api(`api/settings`, {
+      await api(`api/project-settings`, {
         data: newSettings,
         method: 'POST',
       })
@@ -141,7 +140,7 @@ const ProjectsSettings = () => {
         emailAddresses: newSettings[field as keyof Settings] as string,
         errors: null,
       }))
-      setSettings({
+      setProjectSettings({
         // @ts-ignore
         data: newSettings,
       })

--- a/frontend/src/components/theme/Header/HeaderNavigation.tsx
+++ b/frontend/src/components/theme/Header/HeaderNavigation.tsx
@@ -90,27 +90,24 @@ const useInternalNavSections = () => {
       ? [{ label: 'Project submissions', url: '/project-submissions' }]
       : []),
     ...(P.canViewV1Projects ? [{ label: 'Projects', url: '/projects' }] : []),
-    // ...(P.canViewProjects || P.canSubmitProjects || P.canRecommendProjects
-    //   ? [
-    //       {
-    //         label: 'Projects Listing',
-    //         menu: [
-    //           P.canViewProjects
-    //             ? { label: 'View projects', url: '/projects-listing/listing' }
-    //             : null,
-    //           P.canSubmitProjects || P.canRecommendProjects
-    //             ? {
-    //                 label: 'IA/BA Portal - Settings',
-    //                 url: '/projects-listing/settings',
-    //               }
-    //             : null,
-    //         ].filter(Boolean),
-    //         url: '/projects-listing/listing',
-    //       },
-    //     ]
-    //   : []),
-    ...(P.canViewProjects
-      ? [{ label: 'Projects Listing', url: '/projects-listing/listing' }]
+    ...(P.canViewProjects || P.canSetProjectSettings
+      ? [
+          {
+            label: 'Projects Listing',
+            menu: [
+              P.canViewProjects
+                ? { label: 'View projects', url: '/projects-listing/listing' }
+                : null,
+              P.canSetProjectSettings
+                ? {
+                    label: 'IA/BA Portal - Settings',
+                    url: '/projects-listing/settings',
+                  }
+                : null,
+            ].filter(Boolean),
+            url: '/projects-listing/listing',
+          },
+        ]
       : []),
     // @ts-ignore
   ].map((item) => nI(item))

--- a/frontend/src/contexts/PermissionsContext.tsx
+++ b/frontend/src/contexts/PermissionsContext.tsx
@@ -21,6 +21,7 @@ interface PermissionsContextProps {
   canAssociateProjects: boolean
   canEditProjects: boolean
   canEditApprovedProjects: boolean
+  canSetProjectSettings: boolean
   canCommentCPCountry: boolean
   canCommentCPSecretariat: boolean
   isCPCountryUserType: boolean

--- a/frontend/src/contexts/PermissionsProvider.tsx
+++ b/frontend/src/contexts/PermissionsProvider.tsx
@@ -62,6 +62,16 @@ const PermissionsProvider = (props: PermissionsProviderProps) => {
   const canEditApprovedProjects = user_permissions.includes(
     'has_project_v2_edit_approved_access',
   )
+  const canEditProjects =
+    canViewProjects &&
+    (canUpdateProjects ||
+      canSubmitProjects ||
+      canRecommendProjects ||
+      canApproveProjects ||
+      canEditApprovedProjects)
+  const canSetProjectSettings = user_permissions.includes(
+    'has_project_settings_access',
+  )
 
   const canCommentCPCountry = user_permissions.includes(
     'can_cp_country_type_comment',
@@ -84,14 +94,6 @@ const PermissionsProvider = (props: PermissionsProviderProps) => {
   const canEditReplenishment = user_permissions.includes(
     'has_replenishment_edit_access',
   )
-
-  const canEditProjects =
-    canViewProjects &&
-    (canUpdateProjects ||
-      canSubmitProjects ||
-      canRecommendProjects ||
-      canApproveProjects ||
-      canEditApprovedProjects)
 
   return (
     <PermissionsContext.Provider
@@ -116,6 +118,7 @@ const PermissionsProvider = (props: PermissionsProviderProps) => {
         canAssociateProjects,
         canEditProjects,
         canEditApprovedProjects,
+        canSetProjectSettings,
         canCommentCPCountry,
         canCommentCPSecretariat,
         isCPCountryUserType,

--- a/frontend/src/slices/createProjectSlice.ts
+++ b/frontend/src/slices/createProjectSlice.ts
@@ -1,7 +1,7 @@
 import type { CreateSliceProps } from '@ors/types/store'
 import type { ProjectsSlice } from '@ors/types/store'
 
-import { defaultSliceData } from '@ors/helpers/Store/Store'
+import { defaultSliceData, setSlice } from '@ors/helpers/Store/Store'
 
 export const createProjectSlice = ({
   initialState,
@@ -14,6 +14,13 @@ export const createProjectSlice = ({
     meetings: {
       ...defaultSliceData,
       ...(initialState?.projects?.meetings || {}),
+    },
+    setProjectSettings: (project_settings) => {
+      setSlice('projects.project_settings', project_settings)
+    },
+    project_settings: {
+      ...defaultSliceData,
+      ...(initialState?.projects?.project_settings || {}),
     },
     sectors: {
       ...defaultSliceData,

--- a/multilateralfund/settings.py
+++ b/multilateralfund/settings.py
@@ -234,9 +234,24 @@ CONSTANCE_CONFIG = {
         "Email addresses that receive email notifications (comma-separated)",
         str,
     ),
-    "PROJECT_SUBMISSION_NOTIFICATION_EMAILS": (
+    "PROJECT_SUBMISSION_NOTIFICATIONS_ENABLED": (
+        False,
+        "Enable project submission notifications",
+        bool,
+    ),
+    "PROJECT_SUBMISSION_NOTIFICATIONS_EMAILS": (
         "",
         "Email addresses that receive project submission notifications (comma-separated)",
+        str,
+    ),
+    "PROJECT_RECOMMENDATION_NOTIFICATIONS_ENABLED": (
+        False,
+        "Enable project recommendation notifications",
+        bool,
+    ),
+    "PROJECT_RECOMMENDATION_NOTIFICATIONS_EMAILS": (
+        "",
+        "Email addresses that receive project recommendation notifications (comma-separated)",
         str,
     ),
     "DEFAULT_REPLENISHMENT_AS_OF_DATE": (


### PR DESCRIPTION
* Added the /project-settings/ endpoint for handling Project settings and restricted access to only users who have 'has_project_settings_access' permission.
Please run the following scripts to apply the changes:

        python manage.py import_user_permissions import_permissions
        python manage.py import_user_permissions import_user_groups


* Fixed project export for previous versions
* Fix code ordering in project listing
* Copy subsectors into project previous version on version increasing