### PR TITLE
Filter project substances and blends

### DIFF
--- a/core/api/serializers/project_enterprise.py
+++ b/core/api/serializers/project_enterprise.py
@@ -1,5 +1,10 @@
 from rest_framework import serializers
 
+from core.api.utils import PROJECT_SUBSTANCES_ACCEPTED_ANNEXES
+from core.models import (
+    Blend,
+    Substance,
+)
 from core.models.project_enterprise import (
     Enterprise,
     ProjectEnterprise,
@@ -119,6 +124,21 @@ class ProjectEnterpriseOdsOdpSerializer(serializers.ModelSerializer):
                     "Cannot update ods_blend when ods_substance is set"
                 )
 
+        if attrs.get("ods_substance"):
+            accepted_substances = (
+                Substance.objects.all().filter_project_accepted_substances()
+            )
+            if not accepted_substances.filter(id=attrs["ods_substance"].id).exists():
+                raise serializers.ValidationError(
+                    f"Substance must be one of {PROJECT_SUBSTANCES_ACCEPTED_ANNEXES} groups"
+                )
+
+        if attrs.get("ods_blend"):
+            accepted_blends = Blend.objects.all().filter_project_accepted_blends()
+            if not accepted_blends.filter(id=attrs["ods_blend"].id).exists():
+                raise serializers.ValidationError(
+                    f"Blend must have at least one substance in {PROJECT_SUBSTANCES_ACCEPTED_ANNEXES} groups"
+                )
         return super().validate(attrs)
 
 

--- a/core/api/serializers/project_metadata.py
+++ b/core/api/serializers/project_metadata.py
@@ -260,15 +260,19 @@ class ProjectFieldSerializer(ProjectFieldListSerializer):
         if obj.read_field_name == "ods_display_name":
             data = {}
 
-            data["substances"] = SubstanceSerializer(
-                Substance.objects.all().order_by("name"), many=True
-            ).data
+            substances = (
+                Substance.objects.all()
+                .filter_project_accepted_substances()
+                .order_by("name")
+            )
+            data["substances"] = SubstanceSerializer(substances, many=True).data
             for entry in data["substances"]:
                 entry["baseline_type"] = "substance"
 
-            data["blends"] = BlendSerializer(
-                Blend.objects.all().order_by("name"), many=True
-            ).data
+            blends = (
+                Blend.objects.all().filter_project_accepted_blends().order_by("name")
+            )
+            data["blends"] = BlendSerializer(blends, many=True).data
             for entry in data["blends"]:
                 entry["baseline_type"] = "blend"
 

--- a/core/api/serializers/project_v2.py
+++ b/core/api/serializers/project_v2.py
@@ -659,25 +659,19 @@ class ProjectV2OdsOdpCreateUpdateSerializer(ProjectOdsOdpCreateSerializer):
                 raise serializers.ValidationError(
                     "Cannot update ods_blend_id when ods_substance_id is set"
                 )
-        if attrs.get("ods_substance_id"):
-            accepted_substances = Substance.objects.filter(
-                group__name_alt__in=PROJECT_SUBSTANCES_ACCEPTED_ANNEXES
-            )
 
+        if attrs.get("ods_substance_id"):
+            accepted_substances = (
+                Substance.objects.all().filter_project_accepted_substances()
+            )
             if not accepted_substances.filter(id=attrs["ods_substance_id"]).exists():
                 raise serializers.ValidationError(
                     f"Substance must be one of {PROJECT_SUBSTANCES_ACCEPTED_ANNEXES} groups"
                 )
 
         if attrs.get("ods_blend_id"):
-            accepted_substances = Substance.objects.filter(
-                group__name_alt__in=PROJECT_SUBSTANCES_ACCEPTED_ANNEXES
-            )
-            blend = Blend.objects.get(id=attrs["ods_blend_id"])
-            composition = blend.composition or ""
-            if not any(
-                f"{subst.name}=" in composition for subst in accepted_substances
-            ):
+            accepted_blends = Blend.objects.all().filter_project_accepted_blends()
+            if not accepted_blends.filter(id=attrs["ods_blend_id"]).exists():
                 raise serializers.ValidationError(
                     f"Blend must have at least one substance in {PROJECT_SUBSTANCES_ACCEPTED_ANNEXES} groups"
                 )

--- a/core/api/tests/projects/test_project_enterprise.py
+++ b/core/api/tests/projects/test_project_enterprise.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture(name="_setup_enterprises")
-def setup_enterprises(project, project2, new_country, new_agency):
+def setup_enterprises(project, project2, new_country, new_agency, substance_hcfc):
     project2.country = new_country
     project2.meta_project.lead_agency = new_agency
     project2.save()
@@ -28,13 +28,19 @@ def setup_enterprises(project, project2, new_country, new_agency):
     project_enterprise1 = ProjectEnterprise.objects.create(
         project=project, enterprise=enterprise1
     )
-    ProjectEnterpriseOdsOdp.objects.create(project_enterprise=project_enterprise1)
-    ProjectEnterpriseOdsOdp.objects.create(project_enterprise=project_enterprise1)
+    ProjectEnterpriseOdsOdp.objects.create(
+        project_enterprise=project_enterprise1, ods_substance=substance_hcfc
+    )
+    ProjectEnterpriseOdsOdp.objects.create(
+        project_enterprise=project_enterprise1, ods_substance=substance_hcfc
+    )
     project_enterprise2 = ProjectEnterprise.objects.create(
         project=project2,
         enterprise=enterprise2,
     )
-    ProjectEnterpriseOdsOdp.objects.create(project_enterprise=project_enterprise2)
+    ProjectEnterpriseOdsOdp.objects.create(
+        project_enterprise=project_enterprise2, ods_substance=substance_hcfc
+    )
     project_enterprise3 = ProjectEnterprise.objects.create(
         project=project2,
         enterprise=enterprise3,
@@ -45,7 +51,7 @@ def setup_enterprises(project, project2, new_country, new_agency):
 class TestListProjectEnterprise(BaseTest):
     url = reverse("project-enterprise-list")
 
-    def test_project_list_permissions(
+    def test_enterprise_list_permissions(
         self,
         _setup_enterprises,
         user,
@@ -269,7 +275,15 @@ class TestCreateProjectEnterprise:
     client = APIClient()
     url = reverse("project-enterprise-list")
 
-    def get_create_data(self, project, substance, blend, agency):
+    def get_create_data(
+        self,
+        project,
+        substance,
+        blend,
+        agency,
+    ):
+        blend.composition = f"{substance.name}: 100%"
+        blend.save()
         return {
             "project": project.id,
             "enterprise": {
@@ -301,7 +315,7 @@ class TestCreateProjectEnterprise:
             ],
         }
 
-    def test_project_create_permissions(
+    def test_enterprise_create_permissions(
         self,
         _setup_enterprises,
         user,
@@ -317,10 +331,10 @@ class TestCreateProjectEnterprise:
         admin_user,
         project,
         agency,
-        substance,
+        substance_hcfc,
         blend,
     ):
-        data = self.get_create_data(project, substance, blend, agency)
+        data = self.get_create_data(project, substance_hcfc, blend, agency)
 
         def _test_user(user, expected_status, data):
             self.client.force_authenticate(user=user)
@@ -346,9 +360,9 @@ class TestCreateProjectEnterprise:
         _test_user(mlfs_admin_user, 201, data)
         _test_user(admin_user, 201, data)
 
-    def test_create(self, mlfs_admin_user, project, substance, blend, agency):
+    def test_create(self, mlfs_admin_user, project, substance_hcfc, blend, agency):
         self.client.force_authenticate(user=mlfs_admin_user)
-        data = self.get_create_data(project, substance, blend, agency)
+        data = self.get_create_data(project, substance_hcfc, blend, agency)
         assert ProjectEnterprise.objects.all().count() == 0
         response = self.client.post(self.url, data, format="json")
         assert response.status_code == 201
@@ -365,7 +379,7 @@ class TestCreateProjectEnterprise:
         assert project_enterprise.enterprise.remarks == "Some remarks"
         assert project_enterprise.project == project
         assert project_enterprise.ods_odp.count() == 2
-        ods_odp_1 = project_enterprise.ods_odp.get(ods_substance=substance)
+        ods_odp_1 = project_enterprise.ods_odp.get(ods_substance=substance_hcfc)
         assert ods_odp_1.phase_out_mt == 10.0
         assert ods_odp_1.ods_replacement == "Alternative Tech 1"
         assert ods_odp_1.ods_replacement_phase_in == 50.0
@@ -379,8 +393,10 @@ class TestUpdateProjectEnterprise:
 
     client = APIClient()
 
-    def get_update_data(self, project, substance, blend, enterprise, agency):
+    def get_update_data(self, project, substance_hcfc, blend, enterprise, agency):
         ods_odp = enterprise.ods_odp.first()
+        blend.composition = f"{substance_hcfc.name}: 100%"
+        blend.save()
         return {
             "id": enterprise.id,
             "project": project.id,
@@ -400,7 +416,7 @@ class TestUpdateProjectEnterprise:
             "ods_odp": [
                 {
                     "ods_odp": ods_odp.id,
-                    "ods_substance": substance.id,
+                    "ods_substance": substance_hcfc.id,
                     "phase_out_mt": 15.0,
                     "ods_replacement": "Updated Alternative Tech 1",
                     "ods_replacement_phase_in": 50.0,
@@ -429,12 +445,13 @@ class TestUpdateProjectEnterprise:
         mlfs_admin_user,
         admin_user,
         project,
-        substance,
+        substance_hcfc,
         blend,
         agency,
     ):
         enterprise1, _, _ = _setup_enterprises
-        data = self.get_update_data(project, substance, blend, enterprise1, agency)
+
+        data = self.get_update_data(project, substance_hcfc, blend, enterprise1, agency)
 
         def _test_user(user, expected_status, enterprise, data):
             url = reverse("project-enterprise-detail", args=[enterprise.id])
@@ -465,12 +482,18 @@ class TestUpdateProjectEnterprise:
         _test_user(admin_user, 200, enterprise1, data)
 
     def test_update(
-        self, mlfs_admin_user, _setup_enterprises, project, substance, blend, agency
+        self,
+        mlfs_admin_user,
+        _setup_enterprises,
+        project,
+        substance_hcfc,
+        blend,
+        agency,
     ):
         project_enterprise1, _, _ = _setup_enterprises
         self.client.force_authenticate(user=mlfs_admin_user)
         data = self.get_update_data(
-            project, substance, blend, project_enterprise1, agency
+            project, substance_hcfc, blend, project_enterprise1, agency
         )
         url = reverse("project-enterprise-detail", args=[project_enterprise1.id])
         response = self.client.put(url, data, format="json")
@@ -487,7 +510,7 @@ class TestUpdateProjectEnterprise:
         assert project_enterprise1.enterprise.remarks == "Updated remarks"
         assert project_enterprise1.project == project
         assert project_enterprise1.ods_odp.count() == 2
-        ods_odp_1 = project_enterprise1.ods_odp.get(ods_substance=substance)
+        ods_odp_1 = project_enterprise1.ods_odp.get(ods_substance=substance_hcfc)
         assert ods_odp_1.phase_out_mt == 15.0
         assert ods_odp_1.ods_replacement == "Updated Alternative Tech 1"
         assert ods_odp_1.ods_replacement_phase_in == 50.0

--- a/core/api/tests/projects/test_project_utilities.py
+++ b/core/api/tests/projects/test_project_utilities.py
@@ -321,7 +321,7 @@ class TestProjectCluster(BaseTest):
 
 
 @pytest.fixture(name="_setup_project_specific_fields")
-def setup_project_specific_fields():
+def setup_project_specific_fields(groupHCFC):
     cluster1 = ProjectClusterFactory.create(name="Cluster1", code="CL1", sort_order=1)
     project_type1 = ProjectTypeFactory.create(name="Type1", code="TYP1")
     sector1 = ProjectSectorFactory.create(name="Sector1", code="SEC1")
@@ -341,7 +341,10 @@ def setup_project_specific_fields():
         section="section1",
         sort_order=1,
     )
-    substance = SubstanceFactory.create()
+    substance = SubstanceFactory.create(
+        name="Substance1",
+        group=groupHCFC,
+    )
     field2 = ProjectFieldFactory.create(
         import_name="EE demonstration project included (yes/no)",
         label="EE demonstration project included",

--- a/core/api/tests/projects/test_projects_v2.py
+++ b/core/api/tests/projects/test_projects_v2.py
@@ -190,7 +190,7 @@ def setup_project_create(
     meeting,
     subsector,
     project_cluster_kip,
-    groupA,
+    groupHCFC,
     decision,
 ):
     statuses_dict = [
@@ -217,13 +217,13 @@ def setup_project_create(
     )
 
     substA = SubstanceFactory.create(
-        name="SubstanceA", odp=0.02, gwp=0.05, group=groupA
+        name="SubstanceA", odp=0.02, gwp=0.05, group=groupHCFC
     )
     blend = BlendFactory.create(
         name="Blend 1",
+        composition=f"{substA.name}= 0.5",
         sort_order=1,
     )
-
     return {
         "ad_hoc_pcr": True,
         "agency": agency.id,
@@ -241,7 +241,7 @@ def setup_project_create(
         "destruction_technology": "D1",
         "excom_provision": "test excom provision",
         "funding_window": "test funding window",
-        "group": groupA.id,
+        "group": groupHCFC.id,
         "individual_consideration": False,
         "is_lvc": True,
         "is_sme": False,
@@ -1149,16 +1149,15 @@ class TestProjectsV2Update:
         project_url,
         project,
         project_ods_odp_subst,
-        substance,
+        substance_hcfc,
     ):
         ods_odp_to_delete = ProjectOdsOdpFactory.create(
             project=project,
-            ods_substance_id=substance.id,
+            ods_substance_id=substance_hcfc.id,
             odp=0.02,
         )
         blend = BlendFactory.create(
-            name="test blend",
-            sort_order=1,
+            name="test blend", sort_order=1, composition=f"{substance_hcfc.name}=100"
         )
         self.client.force_authenticate(user=agency_user)
         update_data = {

--- a/core/api/utils.py
+++ b/core/api/utils.py
@@ -44,6 +44,11 @@ PROJECT_SECTOR_TYPE_MAPPING = {
     "TAS": ["TAS"],
 }
 
+PROJECT_SUBSTANCES_ACCEPTED_ANNEXES = [
+    "Annex C, Group I",
+    "Annex F",
+]
+
 
 class RelatedExistsFilter(filters.BooleanFilter):
     """Filter query based on whether it has at least one row in the specified related field."""

--- a/core/api/views/chemicals.py
+++ b/core/api/views/chemicals.py
@@ -231,7 +231,9 @@ class BlendsListView(ChemicalBaseListView):
             openapi.Parameter(
                 "filter_for_projects",
                 openapi.IN_QUERY,
-                description=f"Include only blends that have at least one substance in their composition of {PROJECT_SUBSTANCES_ACCEPTED_ANNEXES} groups",
+                description=f"""
+                    Include only blends that have at least one
+                    substance in their composition of {PROJECT_SUBSTANCES_ACCEPTED_ANNEXES} groups""",
                 type=openapi.TYPE_BOOLEAN,
             ),
             openapi.Parameter(

--- a/core/models/substance.py
+++ b/core/models/substance.py
@@ -1,6 +1,15 @@
 from django.conf import settings
 from django.db import models
 
+# pylint: disable=C0415
+
+
+class SubstanceQuerySet(models.QuerySet):
+    def filter_project_accepted_substances(self):
+        from core.api.utils import PROJECT_SUBSTANCES_ACCEPTED_ANNEXES
+
+        return self.filter(group__name_alt__in=PROJECT_SUBSTANCES_ACCEPTED_ANNEXES)
+
 
 class SubstanceManager(models.Manager):
     def find_by_name(self, name):
@@ -22,6 +31,9 @@ class SubstanceManager(models.Manager):
             return substance_alt_name.substance
 
         return None
+
+    def get_queryset(self):
+        return SubstanceQuerySet(self.model, using=self._db)
 
 
 # substance model


### PR DESCRIPTION
Add a query param `filter_for_projects` on both `api/blends` and `api/substances` that returns
* For `api/substances` - only substances with group Annex C, Group I, Annex F
* For `api/blends` - only blends that have in their composition at least one of the substances above (uses substance name for identification)
* Validate ProjectOdsOdp to only accept those substances/blends.