### PR TITLE
APR - Making sure a single project-code column does not get pasted

### DIFF
--- a/frontend/src/components/manage/Blocks/BusinessPlans/BPEdit/pasteSupport/index.tsx
+++ b/frontend/src/components/manage/Blocks/BusinessPlans/BPEdit/pasteSupport/index.tsx
@@ -92,6 +92,13 @@ export async function readPastedTableFromNavigator(
       : parsePastedText(textContent)
 
     const cleanTable = removeEmptyRowsAndColumns(pastedTable)
+    if (cleanTable.length === 0 || cleanTable[0].length < 2) {
+      throwError(
+        'Could not read a valid table from clipboard! Make sure you are pasting a 2 column table.',
+        { variant: 'error' },
+      )
+      return []
+    }
     result = getOnlyFirstAndLastColumns(cleanTable)
   } catch (error) {
     if (error.name === 'NotFoundError') {


### PR DESCRIPTION
Right now, if we only select the "Project code" column and paste it into another text column (e.g. "Remarks"), it will get pasted without issue.