### PR TITLE
Fix authentication flow

### DIFF
--- a/frontend/src/@types/store.d.ts
+++ b/frontend/src/@types/store.d.ts
@@ -260,7 +260,7 @@ export interface ThemeSlice {
 
 export interface UserSlice
   extends SliceData<ApiUser, Record<string, any> | null | undefined> {
-  getUser: () => Promise<void>
+  getUser: () => Promise<ApiUser | null>
   login: (username: string, password: string) => void
   logout: () => Promise<void>
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { ApiAgency } from '@ors/@types/api_agencies'
-import { ApiUser } from '@ors/types/api_auth_user'
 import { ApiBlend } from '@ors/types/api_blends'
 import { ApiSubstance } from '@ors/types/api_substances'
 import { Country } from '@ors/types/store'
@@ -10,12 +9,12 @@ import { useStore } from '@ors/store'
 
 import cx from 'classnames'
 
-import { useLocation } from 'wouter'
+import { useLocation, useSearch } from 'wouter'
 
 import View from '@ors/components/theme/Views/View'
 // import View from '../components/theme/Views/View'
 import api from '@ors/helpers/Api/_api'
-import { getInitialSliceData } from '@ors/helpers/Store/Store'
+import { getInitialSliceData, setSlice } from '@ors/helpers/Store/Store'
 import { getCurrentView } from '@ors/helpers/View/View'
 import { StoreProvider } from '@ors/store'
 import ThemeProvider from '@ors/themes/ThemeProvider'
@@ -30,157 +29,230 @@ import { ProjectSubSectorType } from '@ors/types/api_project_subsector.ts'
 import { ProjectSubmissionStatusType } from '@ors/types/api_project_submission_statuses.ts'
 import { ProjectSubstancesGroupsType } from '@ors/types/api_project_substances_groups'
 
-function useUser() {
-  const [userData, setUserData] = useState<{
-    loaded: boolean
-    user?: null | ApiUser
-  }>({ loaded: false, user: null })
+async function fetchAppBootstrapData() {
+  const [
+    // Common data
+    settings,
+    user_permissions,
+    agencies,
+    countries,
+    // Projects data
+    statuses,
+    submission_statuses,
+    sectors,
+    subsectors,
+    types,
+    meetings,
+    decisions,
+    clusters,
+    substances_groups,
+    // Country programme data
+    blends,
+    substances,
+  ] = await Promise.all([
+    api('api/settings/', {}, false),
+    api('api/user/permissions/', {}, false),
+    api(
+      'api/agencies/',
+      { params: { include_all_agencies_option: true } },
+      false,
+    ),
+    api('api/countries/', {}, false),
+    api('api/project-statuses/', {}, false),
+    api('api/project-submission-statuses/', {}, false),
+    api('api/project-sector/', {}, false),
+    api('api/project-subsector/', {}, false),
+    api('api/project-types/', {}, false),
+    api('api/meetings/', {}, false),
+    api('api/decisions/', {}, false),
+    api('api/project-clusters/', {}, false),
+    api('api/groups/', {}, false),
+    api(
+      'api/blends/',
+      { params: { with_alt_names: true, with_usages: true } },
+      false,
+    ),
+    api(
+      'api/substances/',
+      { params: { with_alt_names: true, with_usages: true } },
+      false,
+    ),
+    // api('api/usages/', {}, false),
+  ])
 
-  useEffect(function () {
-    async function fetchUser() {
-      try {
-        const apiUser = await api<ApiUser>('api/auth/user/', {})
-        setUserData({ loaded: true, user: apiUser })
-      } catch (error) {
-        setUserData({ loaded: true, user: null })
-      }
-    }
-    fetchUser()
-  }, [])
-
-  return userData
+  return {
+    businessPlans: {
+      decisions: getInitialSliceData(decisions),
+      sectors: getInitialSliceData(sectors),
+      subsectors: getInitialSliceData(subsectors),
+      types: getInitialSliceData(types),
+    },
+    common: {
+      agencies: getInitialSliceData(
+        agencies.filter((a: ApiAgency) => a.name !== 'All agencies'),
+      ),
+      agencies_with_all: getInitialSliceData(agencies),
+      countries: getInitialSliceData<Country[]>(countries),
+      countries_for_create: getInitialSliceData<Country[]>(
+        countries.filter((c: Country) => c.has_cp_report && !c.is_a2),
+      ),
+      countries_for_listing: getInitialSliceData<Country[]>(
+        countries.filter((c: Country) => c.has_cp_report),
+      ),
+      settings: getInitialSliceData(settings),
+      user_permissions: getInitialSliceData(user_permissions),
+    },
+    cp_reports: {
+      blends: getInitialSliceData<ApiBlend[]>(blends),
+      substances: getInitialSliceData<ApiSubstance[]>(substances),
+    },
+    projects: {
+      clusters: getInitialSliceData(clusters),
+      meetings: getInitialSliceData(meetings),
+      sectors: getInitialSliceData<ProjectSectorType[]>(sectors),
+      statuses: getInitialSliceData<ProjectStatusType[]>(statuses),
+      submission_statuses:
+        getInitialSliceData<ProjectSubmissionStatusType[]>(submission_statuses),
+      subsectors: getInitialSliceData<ProjectSubSectorType[]>(subsectors),
+      substances_groups:
+        getInitialSliceData<ProjectSubstancesGroupsType[]>(substances_groups),
+      types: getInitialSliceData(types),
+    },
+  }
 }
 
-function useAppState(user: ApiUser | null | undefined) {
-  const [state, setState] = useState<any>(null)
+function setAppBootstrapData(
+  appData: Awaited<ReturnType<typeof fetchAppBootstrapData>>,
+) {
+  setSlice('businessPlans', appData.businessPlans)
+  setSlice('common', appData.common)
+  setSlice('cp_reports', appData.cp_reports)
+  setSlice('projects', appData.projects)
+}
+
+function useAppBootstrap(userId?: number) {
+  const [bootstrappedUserId, setBootstrappedUserId] = useState<null | number>(
+    null,
+  )
 
   useEffect(
     function () {
-      async function fetchState() {
-        const [
-          // Common data
-          settings,
-          user_permissions,
-          agencies,
-          countries,
-          // Projects data
-          statuses,
-          submission_statuses,
-          sectors,
-          subsectors,
-          types,
-          meetings,
-          decisions,
-          clusters,
-          substances_groups,
-          // Country programme data
-          blends,
-          substances,
-        ] = await Promise.all([
-          api('api/settings/', {}, false),
-          api('api/user/permissions/', {}, false),
-          api(
-            'api/agencies/',
-            { params: { include_all_agencies_option: true } },
-            false,
-          ),
-          api('api/countries/', {}, false),
-          api('api/project-statuses/', {}, false),
-          api('api/project-submission-statuses/', {}, false),
-          api('api/project-sector/', {}, false),
-          api('api/project-subsector/', {}, false),
-          api('api/project-types/', {}, false),
-          api('api/meetings/', {}, false),
-          api('api/decisions/', {}, false),
-          api('api/project-clusters/', {}, false),
-          api('api/groups/', {}, false),
-          api(
-            'api/blends/',
-            { params: { with_alt_names: true, with_usages: true } },
-            false,
-          ),
-          api(
-            'api/substances/',
-            { params: { with_alt_names: true, with_usages: true } },
-            false,
-          ),
-          // api('api/usages/', {}, false),
-        ])
+      let ignore = false
 
-        const common = {
-          agencies: getInitialSliceData(
-            agencies.filter((a: ApiAgency) => a.name !== 'All agencies'),
-          ),
-          agencies_with_all: getInitialSliceData(agencies),
-          countries: getInitialSliceData<Country[]>(countries),
-          countries_for_create: getInitialSliceData<Country[]>(
-            countries.filter((c: Country) => c.has_cp_report && !c.is_a2),
-          ),
-          countries_for_listing: getInitialSliceData<Country[]>(
-            countries.filter((c: Country) => c.has_cp_report),
-          ),
-          settings: getInitialSliceData(settings),
-          user_permissions: getInitialSliceData(user_permissions),
-        }
-        const projects = {
-          clusters: getInitialSliceData(clusters),
-          meetings: getInitialSliceData(meetings),
-          sectors: getInitialSliceData<ProjectSectorType[]>(sectors),
-          statuses: getInitialSliceData<ProjectStatusType[]>(statuses),
-          submission_statuses:
-            getInitialSliceData<ProjectSubmissionStatusType[]>(
-              submission_statuses,
-            ),
-          subsectors: getInitialSliceData<ProjectSubSectorType[]>(subsectors),
-          types: getInitialSliceData(types),
-          substances_groups:
-            getInitialSliceData<ProjectSubstancesGroupsType[]>(
-              substances_groups,
-            ),
-        }
-        const cp_reports = {
-          blends: getInitialSliceData<ApiBlend[]>(blends),
-          substances: getInitialSliceData<ApiSubstance[]>(substances),
-        }
-        const businessPlans = {
-          sectors: getInitialSliceData(sectors),
-          subsectors: getInitialSliceData(subsectors),
-          types: getInitialSliceData(types),
-          decisions: getInitialSliceData(decisions),
-        }
+      async function bootstrapAppData() {
+        const appData = await fetchAppBootstrapData()
 
-        setState({ common, projects, cp_reports, businessPlans })
+        if (!ignore) {
+          setAppBootstrapData(appData)
+          setBootstrappedUserId(userId ?? null)
+        }
       }
 
-      if (user) {
-        fetchState()
+      if (!userId) {
+        setBootstrappedUserId(null)
+        return
+      }
+
+      setBootstrappedUserId(null)
+      bootstrapAppData()
+
+      return () => {
+        ignore = true
       }
     },
-    [user],
+    [userId],
   )
 
-  return state
+  return !!userId && bootstrappedUserId === userId
 }
 
-function LoginWrapper(props: any) {
-  const { appState, children, setCurrentUser } = props
-  const [pathname] = useLocation()
-  const user = useStore((state) => state.user)
+function getCurrentPath(pathname: string, search: string) {
+  return `${pathname || '/'}${search ? `?${search}` : ''}`
+}
 
-  useEffect(() => {
-    setCurrentUser(user)
-  }, [user])
+function getLoginPath(pathname: string, search: string) {
+  const redirectPath = getCurrentPath(pathname, search)
+
+  return redirectPath !== '/'
+    ? `/login?redirect=${encodeURIComponent(redirectPath)}`
+    : '/login'
+}
+
+function getPostLoginPath(searchParams: URLSearchParams) {
+  const redirectPath = searchParams.get('redirect')
+
+  if (
+    redirectPath &&
+    redirectPath.startsWith('/') &&
+    !redirectPath.startsWith('//') &&
+    redirectPath !== '/login' &&
+    !redirectPath.startsWith('/login?')
+  ) {
+    return redirectPath
+  }
+
+  return '/'
+}
+
+function ClientAppGate({ children }: { children: React.ReactNode }) {
+  const [pathname, setLocation] = useLocation()
+  const search = useSearch()
+  const searchParams = useSearchParams()
+  const user = useStore((state) => state.user)
+  const getUser = useStore((state) => state.user.getUser)
+  const appBootstrapped = useAppBootstrap(user.data?.pk)
 
   const currentView = getCurrentView(pathname || '')
+  const isLoginPath = pathname === '/login'
+  const isProtectedPath =
+    currentView.layout === 'authorized_document' ||
+    currentView.layout === 'print'
+
+  useEffect(() => {
+    getUser()
+  }, [getUser])
+
+  useEffect(() => {
+    if (!user.loaded) {
+      return
+    }
+
+    if (isLoginPath && user.data) {
+      setLocation(getPostLoginPath(searchParams), { replace: true })
+      return
+    }
+
+    if (isProtectedPath && !user.data) {
+      setLocation(getLoginPath(pathname, search), { replace: true })
+    }
+  }, [
+    isLoginPath,
+    isProtectedPath,
+    pathname,
+    search,
+    searchParams,
+    setLocation,
+    user.data,
+    user.loaded,
+  ])
 
   const shouldRenderView = useMemo(
     function () {
-      const isAuthorized = currentView.layout === 'authorized_document'
-      const haveUser = user.loaded && user.data && appState
-      const unauthenticatedPath = user.loaded && !user.data && !isAuthorized
-      return haveUser || unauthenticatedPath
+      if (!user.loaded) {
+        return false
+      }
+
+      if (isLoginPath && user.data) {
+        return false
+      }
+
+      if (isProtectedPath) {
+        return Boolean(user.data && appBootstrapped)
+      }
+
+      return true
     },
-    [user.loaded, user.data, appState, currentView.layout],
+    [appBootstrapped, isLoginPath, isProtectedPath, user.data, user.loaded],
   )
 
   return <View>{shouldRenderView ? children : null}</View>
@@ -192,40 +264,21 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   // const cookies = nextCookies()
-  const [pathname, setLocation] = useLocation()
-  const searchParams = useSearchParams()
   const theme = { value: 'light' }
-
-  const { user, loaded: userLoaded } = useUser()
-  const appState = useAppState(user)
-  const [currentUser, setCurrentUser] = useState<any>()
-
-  useEffect(() => {
-    const isLoginPath = pathname === '/login'
-    if (user && currentUser?.data && currentUser?.loaded && isLoginPath) {
-      setTimeout(() => {
-        setLocation(searchParams.get('redirect') || '/')
-      }, 500)
-    }
-  }, [user, pathname, userLoaded, setLocation, searchParams, currentUser])
 
   return (
     <div id="layout" className={cx('h-full')}>
       <StoreProvider
         initialState={{
-          ...appState,
           theme: {
             mode: theme.value as 'dark' | 'light' | null,
           },
-          user: { data: user, loaded: userLoaded },
         }}
       >
         <ThemeProvider>
           <PermissionsProvider>
             <UpdatedFieldsProvider>
-              <LoginWrapper appState={appState} setCurrentUser={setCurrentUser}>
-                {children}
-              </LoginWrapper>
+              <ClientAppGate>{children}</ClientAppGate>
             </UpdatedFieldsProvider>
           </PermissionsProvider>
         </ThemeProvider>

--- a/frontend/src/components/theme/Forms/LoginForm/EntraIdLoginButton.tsx
+++ b/frontend/src/components/theme/Forms/LoginForm/EntraIdLoginButton.tsx
@@ -6,9 +6,11 @@ import { enqueueSnackbar } from 'notistack'
 import { useMsal } from '@azure/msal-react'
 import { Button } from '@mui/material'
 import cx from 'classnames'
+import { useStore } from '@ors/store'
 
 const EntraIdLoginButton = () => {
   const { instance } = useMsal()
+  const user = useStore((state) => state.user)
 
   const handleLogin = async () => {
     try {
@@ -17,6 +19,16 @@ const EntraIdLoginButton = () => {
 
       if (account) {
         instance.setActiveAccount(account)
+
+        const apiUser = await user.getUser()
+
+        if (!apiUser) {
+          enqueueSnackbar(
+            <>An error occurred during sign in. Please try again.</>,
+            { variant: 'error' },
+          )
+        }
+
         return
       }
 

--- a/frontend/src/components/theme/Forms/LoginForm/LoginForm.tsx
+++ b/frontend/src/components/theme/Forms/LoginForm/LoginForm.tsx
@@ -1,28 +1,15 @@
 import EntraIdLoginButton from './EntraIdLoginButton'
 
 import { Alert, Button, Collapse, Paper, Typography } from '@mui/material'
-import { useLocation } from 'wouter'
-import useSearchParams from '@ors/hooks/useSearchParams'
 
 import Field from '@ors/components/manage/Form/Field'
 import LoadingBuffer from '@ors/components/theme/Loading/LoadingBuffer'
 import Link from '@ors/components/ui/Link/Link'
 
 import { useStore } from '@ors/store'
-import { store } from '@ors/_store'
 
 export default function LoginForm() {
-  const [_, setLocation] = useLocation()
-  const searchParams = useSearchParams()
   const user = useStore((state) => state.user)
-
-  // useEffect(() => {
-  //   if (user.data) {
-  //     setTimeout(() => {
-  //       setLocation(searchParams.get('redirect') || '/')
-  //     }, 500)
-  //   }
-  // }, [user, setLocation, searchParams])
 
   return (
     <>
@@ -41,12 +28,6 @@ export default function LoginForm() {
             form.get('username')?.toString() || '',
             form.get('password')?.toString() || '',
           )
-
-          const { data, error } = store.current.getState().user
-
-          if (data && !error) {
-            window.location.href = searchParams.get('redirect') || '/'
-          }
         }}
       >
         <Typography

--- a/frontend/src/components/theme/Views/AuthorizedView.tsx
+++ b/frontend/src/components/theme/Views/AuthorizedView.tsx
@@ -1,7 +1,5 @@
 import React from 'react'
 
-import { useLocation } from 'wouter'
-
 import Print from '@ors/components/manage/Utils/Print'
 import Footer from '@ors/components/theme/Footer/AuthorizedFooter'
 import Header from '@ors/components/theme/Header/AuthorizedHeader'
@@ -13,16 +11,7 @@ export default function AuthorizedView({
 }: {
   children: React.ReactNode
 }) {
-  const [pathname, setLocation] = useLocation()
   const user = useStore((state) => state.user?.data)
-
-  React.useEffect(() => {
-    if (!user) {
-      setLocation(
-        pathname && pathname !== '/' ? `/login?redirect=${pathname}` : '/login',
-      )
-    }
-  }, [user, pathname, setLocation])
 
   if (!user) {
     return <Loading className="bg-action-disabledBackground" />

--- a/frontend/src/components/theme/Views/PrintView.tsx
+++ b/frontend/src/components/theme/Views/PrintView.tsx
@@ -1,22 +1,12 @@
 'use client'
 
 import React, { useEffect } from 'react'
-import { useLocation } from 'wouter'
 
 import Loading from '@ors/components/theme/Loading/Loading'
 import { useStore } from '@ors/store'
 
 export default function PrintView({ children }: { children: React.ReactNode }) {
-  const [pathname, setLocation] = useLocation()
   const user = useStore((state) => state.user?.data)
-
-  React.useEffect(() => {
-    if (!user) {
-      setLocation(
-        pathname && pathname !== '/' ? `/login?redirect=${pathname}` : '/login',
-      )
-    }
-  }, [user, pathname, setLocation])
 
   useEffect(() => {
     document.documentElement.setAttribute('data-printing', 'yes')

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,6 +6,7 @@ import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import { initializeSentry } from './instrumentation'
 import { MsalProvider } from '@azure/msal-react'
+import { BrowserAuthErrorCodes } from '@azure/msal-browser'
 
 initializeSentry()
 
@@ -25,7 +26,12 @@ const initializeApp = async () => {
       }
     }
   } catch (err) {
-    console.error(err)
+    if (
+      (err as { errorCode?: string }).errorCode !==
+      BrowserAuthErrorCodes.noTokenRequestCacheError
+    ) {
+      console.error(err)
+    }
   }
 
   createRoot(document.getElementById('main')!).render(

--- a/frontend/src/slices/createUserSlice.ts
+++ b/frontend/src/slices/createUserSlice.ts
@@ -30,6 +30,8 @@ export const createUserSlice = ({
         loaded: true,
         loading: false,
       })
+
+      return apiUser || null
     } catch (error) {
       setSlice('user', {
         data: null,
@@ -37,6 +39,8 @@ export const createUserSlice = ({
         loaded: true,
         loading: false,
       })
+
+      return null
     }
   },
   // Login

--- a/frontend/src/slices/createUserSlice.ts
+++ b/frontend/src/slices/createUserSlice.ts
@@ -6,11 +6,7 @@ import type { UserSlice } from '@ors/types/store'
 import Cookies from 'js-cookie'
 
 import api from '@ors/helpers/Api/_api'
-import {
-  fetchSliceData,
-  getInitialSliceData,
-  setSlice,
-} from '@ors/helpers/Store/Store'
+import { getInitialSliceData, setSlice } from '@ors/helpers/Store/Store'
 
 function removeCookies() {
   Cookies.remove('csrftoken')
@@ -24,7 +20,24 @@ export const createUserSlice = ({
   ...getInitialSliceData<ApiUser, Record<string, any> | null | undefined>(),
   // Get user
   getUser: async () => {
-    fetchSliceData({ apiSettings: { path: 'api/auth/user/' }, slice: 'user' })
+    setSlice('user', { loaded: false, loading: true })
+    try {
+      const apiUser = await api<ApiUser>('api/auth/user/', {})
+
+      setSlice('user', {
+        data: apiUser,
+        error: null,
+        loaded: true,
+        loading: false,
+      })
+    } catch (error) {
+      setSlice('user', {
+        data: null,
+        error,
+        loaded: true,
+        loading: false,
+      })
+    }
   },
   // Login
   login: async (username, password) => {

--- a/frontend/src/store.tsx
+++ b/frontend/src/store.tsx
@@ -5,20 +5,17 @@ import type {
   StoreState,
 } from '@ors/types/store'
 
-import { createContext, useContext, useEffect, useRef, useState } from 'react'
+import { createContext, useContext, useRef } from 'react'
 
-import { merge } from 'lodash'
 import { useStore as useZustandStore } from 'zustand'
 import { useShallow } from 'zustand/react/shallow'
 import { createStore as createZustandStore } from 'zustand/vanilla'
 
 import createSlices from '@ors/slices'
 
-import { setStore, store } from './_store'
+import { setStore } from './_store'
 
 export type Store = ReturnType<typeof createStore>
-
-export const initialStore = createZustandStore<InitialStoreState>(() => ({}))
 
 export const createStore = (initialState: InitialStoreState) => {
   return createZustandStore<StoreState>((set, get) => ({
@@ -29,27 +26,15 @@ export const createStore = (initialState: InitialStoreState) => {
 export const StoreContext = createContext<Store | null>(null)
 
 export function StoreProvider({ children, initialState }: StoreProviderProps) {
-  const [, setMounted] = useState(false)
-  // Set initial store state
-  initialStore.setState(initialState)
-  // Hydrate store with initial state
-  setStore(useRef(createStore(initialStore.getState())))
-  // Re-hydrate store with new initial state
-  const unsubscribeRehydrate = initialStore.subscribe((state, prevState) => {
-    if (JSON.stringify(state) !== JSON.stringify(prevState)) {
-      store.current.setState(merge(store.current.getState(), state))
-    }
-  })
+  const storeRef = useRef<Store | null>(null)
 
-  useEffect(() => {
-    // Unsubscribe store re-hydration on initial render and trigger rerender
-    unsubscribeRehydrate()
-    setMounted(true)
-    /* eslint-disable-next-line */
-  }, [])
+  if (!storeRef.current) {
+    storeRef.current = createStore(initialState)
+    setStore(storeRef)
+  }
 
   return (
-    <StoreContext.Provider value={store.current}>
+    <StoreContext.Provider value={storeRef.current}>
       {children}
     </StoreContext.Provider>
   )


### PR DESCRIPTION
The app now handles auth fully on the client without bouncing authenticated users through /login on refresh. Protected routes wait for the current-user check before redirecting, and shared app bootstrap data is loaded after the backend confirms the user.

It also fixes related login edge cases:

- username/password login returns to the requested page without a full reload,
- logout redirects back to login with the current page preserved,
- cached Microsoft accounts now re-check the backend app user instead of silently doing nothing.

## Changes

- Centralized protected-route and login-route handling in ClientAppGate.
- Simplified StoreProvider so the Zustand store is created once.
- Moved app bootstrap loading into the client auth flow.
- Removed redirect side effects from AuthorizedView and PrintView.
- Removed full-page reload after login.

### More resilient Microsoft authentication

Make the cached-account path prove that the backend app session is valid before treating the user as signed in.

Because the MSAL button needs an immediate answer from the backend user check.

Before, `user.getUser()` only updated the Zustand slice as a side effect and returned `void`. That was fine for app bootstrap, but not enough for this flow:

1. User is on `/login`.
2. MSAL already has a cached account.
3. User clicks “Sign in with Microsoft”.
4. Button calls `instance.setActiveAccount(account)`.
5. Now the button must ask: “Does ORS backend recognize this Microsoft account?”

That answer comes from `api/auth/user/`.

By returning `ApiUser | null`, `getUser()` can now tell the caller:

- `ApiUser`: backend accepted the MSAL token and returned an ORS user. The store is populated, and `ClientAppGate` can redirect.
- `null`: MSAL had an account, but ORS did not authenticate it. Stay on login and show an error.

Without returning the value, the button would have to infer success indirectly from async store updates, which is more fragile and harder to reason about.