### PR TITLE
[refs #36942] Add missing ProjectSpecificFields.

### DIFF
--- a/core/api/export/single_project_v2/as_docx.py
+++ b/core/api/export/single_project_v2/as_docx.py
@@ -422,11 +422,15 @@ class ProjectsV2ProjectExportDocx:
         return result
 
     def build_specific_information(self, data):
-        project_specific_fields_obj = ProjectSpecificFields.objects.filter(
-            cluster=self.project.cluster,
-            type=self.project.project_type,
-            sector=self.project.sector,
-        ).first()
+        project_specific_fields_obj = (
+            ProjectSpecificFields.objects.with_obsolete()
+            .filter(
+                cluster=self.project.cluster,
+                type=self.project.project_type,
+                sector=self.project.sector,
+            )
+            .first()
+        )
 
         if project_specific_fields_obj:
             self._write_project_specific_fields(
@@ -464,11 +468,15 @@ class ProjectsV2ProjectExportDocx:
                 submission_status__name="Approved",
             )
             for project in related_projects:
-                project_specific_fields_obj = ProjectSpecificFields.objects.filter(
-                    cluster=project.cluster,
-                    type=project.project_type,
-                    sector=project.sector,
-                ).first()
+                project_specific_fields_obj = (
+                    ProjectSpecificFields.objects.with_obsolete()
+                    .filter(
+                        cluster=project.cluster,
+                        type=project.project_type,
+                        sector=project.sector,
+                    )
+                    .first()
+                )
 
                 fields = self._get_fields_for_section(
                     "Impact",

--- a/core/api/export/single_project_v2/as_xlsx.py
+++ b/core/api/export/single_project_v2/as_xlsx.py
@@ -138,11 +138,15 @@ class ProjectsV2ProjectExport:
         return result
 
     def build_specific_information(self, data):
-        project_specific_fields_obj = ProjectSpecificFields.objects.filter(
-            cluster=self.project.cluster,
-            type=self.project.project_type,
-            sector=self.project.sector,
-        ).first()
+        project_specific_fields_obj = (
+            ProjectSpecificFields.objects.with_obsolete()
+            .filter(
+                cluster=self.project.cluster,
+                type=self.project.project_type,
+                sector=self.project.sector,
+            )
+            .first()
+        )
 
         if project_specific_fields_obj:
             self._write_project_specific_fields(

--- a/core/api/tests/projects/test_project_utilities.py
+++ b/core/api/tests/projects/test_project_utilities.py
@@ -1,9 +1,18 @@
+import importlib
+import json
+from unittest.mock import patch
+
 import pytest
 from django.urls import reverse
+from django.apps import apps
+from core.import_data_v2.scripts.import_cluster_type_sector_links import (
+    import_cluster_type_sector_links,
+)
 from core.api.tests.base import BaseTest
 
 from core.api.tests.factories import (
     ProjectClusterFactory,
+    ProjectOdsOdpFactory,
     ProjectSpecificFieldsFactory,
     MeetingFactory,
     ProjectFactory,
@@ -14,11 +23,40 @@ from core.api.tests.factories import (
     RbmMeasureFactory,
     SubstanceFactory,
 )
-from core.models.project_metadata import ProjectSector, ProjectSubSector
+from core.models.project_metadata import (
+    ProjectSector,
+    ProjectSpecificFields,
+    ProjectSubSector,
+)
 
 
 pytestmark = pytest.mark.django_db
 # pylint: disable=C8008,W0221
+
+project_specific_fields_obsolete = importlib.import_module(
+    "core.migrations.0305_projectspecificfields_obsolete"
+)
+
+
+def write_cluster_type_sector_import_file(tmp_path, cluster, project_type, sector):
+    file_path = tmp_path / "ClusterTypeSectorLinks.json"
+    file_path.write_text(
+        json.dumps(
+            [
+                {
+                    "cluster": cluster.name,
+                    "types": [
+                        {
+                            "type": project_type.name,
+                            "sectors": [sector.name],
+                        }
+                    ],
+                }
+            ]
+        ),
+        encoding="utf8",
+    )
+    return file_path
 
 
 class TestProjectsStatus(BaseTest):
@@ -69,6 +107,33 @@ class TestProjectSectorList(BaseTest):
             "subsectors": [],
             "obsolete": sector.obsolete,
         }
+
+    def test_project_sector_list_excludes_obsolete_project_specific_fields_mapping(
+        self, viewer_user
+    ):
+        cluster = ProjectClusterFactory.create()
+        project_type = ProjectTypeFactory.create()
+        visible_sector = ProjectSectorFactory.create(sort_order=1)
+        obsolete_mapping_sector = ProjectSectorFactory.create(sort_order=2)
+        ProjectSpecificFieldsFactory.create(
+            cluster=cluster,
+            type=project_type,
+            sector=visible_sector,
+        )
+        ProjectSpecificFieldsFactory.create(
+            cluster=cluster,
+            type=project_type,
+            sector=obsolete_mapping_sector,
+            obsolete=True,
+        )
+
+        self.client.force_authenticate(user=viewer_user)
+        response = self.client.get(
+            self.url, {"cluster_id": cluster.id, "type_id": project_type.id}
+        )
+
+        assert response.status_code == 200
+        assert [sector["id"] for sector in response.data] == [visible_sector.id]
 
 
 @pytest.fixture(name="_setup_sector_create")
@@ -263,6 +328,33 @@ class TestProjectType(BaseTest):
             "obsolete": project_type.obsolete,
         }
 
+    def test_project_type_list_excludes_obsolete_project_specific_fields_mapping(
+        self, viewer_user
+    ):
+        cluster = ProjectClusterFactory.create()
+        visible_type = ProjectTypeFactory.create(sort_order=1)
+        obsolete_mapping_type = ProjectTypeFactory.create(sort_order=2)
+        sector = ProjectSectorFactory.create()
+        ProjectSpecificFieldsFactory.create(
+            cluster=cluster,
+            type=visible_type,
+            sector=sector,
+        )
+        ProjectSpecificFieldsFactory.create(
+            cluster=cluster,
+            type=obsolete_mapping_type,
+            sector=sector,
+            obsolete=True,
+        )
+
+        self.client.force_authenticate(user=viewer_user)
+        response = self.client.get(self.url, {"cluster_id": cluster.id})
+
+        assert response.status_code == 200
+        assert [project_type["id"] for project_type in response.data] == [
+            visible_type.id
+        ]
+
 
 @pytest.fixture(name="_setup_project_meeting")
 def setup_project_meeting(country_ro, agency, project_type, project_status, subsector):
@@ -318,6 +410,33 @@ class TestProjectCluster(BaseTest):
         assert response.data[0]["name"] == project_cluster_kpp.name
         assert response.data[1]["name"] == project_cluster_kip.name
         assert response.data[1]["code"] == project_cluster_kip.code
+
+    def test_project_cluster_list_excludes_obsolete_project_specific_fields_mapping(
+        self, viewer_user
+    ):
+        visible_cluster = ProjectClusterFactory.create(sort_order=1)
+        obsolete_mapping_cluster = ProjectClusterFactory.create(sort_order=2)
+        project_type = ProjectTypeFactory.create()
+        sector = ProjectSectorFactory.create()
+        ProjectSpecificFieldsFactory.create(
+            cluster=visible_cluster,
+            type=project_type,
+            sector=sector,
+        )
+        ProjectSpecificFieldsFactory.create(
+            cluster=obsolete_mapping_cluster,
+            type=project_type,
+            sector=sector,
+            obsolete=True,
+        )
+
+        self.client.force_authenticate(user=viewer_user)
+        response = self.client.get(
+            self.url, {"included_in_type_sector_combinations": "true"}
+        )
+
+        assert response.status_code == 200
+        assert [cluster["id"] for cluster in response.data] == [visible_cluster.id]
 
 
 @pytest.fixture(name="_setup_project_specific_fields")
@@ -400,6 +519,21 @@ class TestProjectFields(BaseTest):
 
 class TestProjectSpecificFields(BaseTest):
 
+    def test_project_specific_fields_obsolete_defaults_to_false(self):
+        project_specific_fields = ProjectSpecificFieldsFactory.create()
+
+        assert project_specific_fields.obsolete is False
+
+    def test_project_specific_fields_objects_excludes_obsolete_by_default(self):
+        visible_mapping = ProjectSpecificFieldsFactory.create()
+        obsolete_mapping = ProjectSpecificFieldsFactory.create(obsolete=True)
+
+        assert list(ProjectSpecificFields.objects.all()) == [visible_mapping]
+        assert set(ProjectSpecificFields.objects.with_obsolete()) == {
+            visible_mapping,
+            obsolete_mapping,
+        }
+
     def test_without_login(self, _setup_project_specific_fields):
         cluster1, project_type1, sector1, _, _, _ = _setup_project_specific_fields
         url = reverse(
@@ -452,6 +586,238 @@ class TestProjectSpecificFields(BaseTest):
         assert fields[1]["data_type"] == field2.data_type
         assert fields[1]["section"] == field2.section
         assert fields[1]["sort_order"] == field2.sort_order
+
+    def test_project_specific_fields_list_includes_obsolete_mapping_for_exact_render(
+        self, viewer_user
+    ):
+        cluster = ProjectClusterFactory.create()
+        project_type = ProjectTypeFactory.create()
+        sector = ProjectSectorFactory.create()
+        project = ProjectFactory.create(
+            cluster=cluster,
+            project_type=project_type,
+            sector=sector,
+        )
+        obsolete_mapping = ProjectSpecificFieldsFactory.create(
+            cluster=cluster,
+            type=project_type,
+            sector=sector,
+            obsolete=True,
+        )
+        ods_field = ProjectFieldFactory.create(
+            import_name="ods_display_name",
+            label="Substance - baseline technology",
+            read_field_name="ods_display_name",
+            write_field_name="ods_display_name",
+            table="ods_odp",
+            data_type="text",
+            section="Substance Details",
+            sort_order=1,
+        )
+        group_field = ProjectFieldFactory.create(
+            import_name="group",
+            label="Annex group of substances",
+            read_field_name="group",
+            write_field_name="group",
+            table="project",
+            data_type="drop_down",
+            section="Header",
+            sort_order=2,
+        )
+        obsolete_mapping.fields.add(ods_field)
+
+        self.client.force_authenticate(user=viewer_user)
+        url = reverse(
+            "project-specific-fields",
+            kwargs={
+                "cluster_id": cluster.id,
+                "type_id": project_type.id,
+                "sector_id": sector.id,
+            },
+        )
+        response = self.client.get(url, {"project_id": project.id})
+
+        assert response.status_code == 200
+        field_names = {field["write_field_name"] for field in response.data["fields"]}
+        assert field_names == {"ods_display_name"}
+        assert group_field.write_field_name not in field_names
+
+    def test_project_specific_fields_list_excludes_obsolete_mapping_without_project(
+        self, viewer_user
+    ):
+        obsolete_mapping = ProjectSpecificFieldsFactory.create(obsolete=True)
+
+        self.client.force_authenticate(user=viewer_user)
+        url = reverse(
+            "project-specific-fields",
+            kwargs={
+                "cluster_id": obsolete_mapping.cluster_id,
+                "type_id": obsolete_mapping.type_id,
+                "sector_id": obsolete_mapping.sector_id,
+            },
+        )
+        response = self.client.get(url)
+
+        assert response.status_code == 404
+
+    def test_project_cluster_type_sector_association_excludes_obsolete_mapping(
+        self, viewer_user
+    ):
+        visible_mapping = ProjectSpecificFieldsFactory.create()
+        obsolete_mapping = ProjectSpecificFieldsFactory.create(obsolete=True)
+
+        self.client.force_authenticate(user=viewer_user)
+        response = self.client.get(reverse("project-cluster-type-sector-association"))
+
+        assert response.status_code == 200
+        cluster_ids = {cluster["cluster_id"] for cluster in response.data}
+        assert visible_mapping.cluster_id in cluster_ids
+        assert obsolete_mapping.cluster_id not in cluster_ids
+
+    def test_import_cluster_type_sector_links_creates_active_mapping(self, tmp_path):
+        cluster = ProjectClusterFactory.create()
+        project_type = ProjectTypeFactory.create()
+        sector = ProjectSectorFactory.create()
+        import_file = write_cluster_type_sector_import_file(
+            tmp_path, cluster, project_type, sector
+        )
+
+        import_cluster_type_sector_links(import_file)
+
+        mapping = ProjectSpecificFields.objects.get(
+            cluster=cluster,
+            type=project_type,
+            sector=sector,
+        )
+        assert mapping.obsolete is False
+
+    def test_import_cluster_type_sector_links_keeps_existing_active_mapping(
+        self, tmp_path
+    ):
+        mapping = ProjectSpecificFieldsFactory.create()
+        import_file = write_cluster_type_sector_import_file(
+            tmp_path, mapping.cluster, mapping.type, mapping.sector
+        )
+
+        import_cluster_type_sector_links(import_file)
+
+        assert (
+            ProjectSpecificFields.objects.with_obsolete()
+            .filter(
+                cluster=mapping.cluster,
+                type=mapping.type,
+                sector=mapping.sector,
+            )
+            .count()
+            == 1
+        )
+        mapping.refresh_from_db()
+        assert mapping.obsolete is False
+
+    def test_import_cluster_type_sector_links_reactivates_obsolete_mapping(
+        self, tmp_path
+    ):
+        mapping = ProjectSpecificFieldsFactory.create(obsolete=True)
+        import_file = write_cluster_type_sector_import_file(
+            tmp_path, mapping.cluster, mapping.type, mapping.sector
+        )
+
+        with patch(
+            "core.import_data_v2.scripts.import_cluster_type_sector_links.logger.warning"
+        ) as warning:
+            import_cluster_type_sector_links(import_file)
+
+        mapping.refresh_from_db()
+        assert mapping.obsolete is False
+        assert ProjectSpecificFields.objects.get(
+            cluster=mapping.cluster,
+            type=mapping.type,
+            sector=mapping.sector,
+        )
+        assert warning.call_count == 1
+        assert (
+            "Reactivating obsolete project-specific fields mapping"
+            in warning.call_args.args[0]
+        )
+
+    def test_obsolete_project_specific_fields_migration_adds_only_ods_combinations(
+        self, project_approved_status
+    ):
+        generic_field_names = (
+            project_specific_fields_obsolete.GENERIC_SUBSTANCE_FIELD_NAMES
+        )
+        for field_name in generic_field_names:
+            ProjectFieldFactory.create(
+                import_name=field_name,
+                label=field_name,
+                read_field_name=field_name,
+                write_field_name=field_name,
+                table="ods_odp",
+                data_type="text",
+                section="Substance Details",
+            )
+        project_with_ods = ProjectFactory.create(
+            submission_status=project_approved_status,
+            cluster=ProjectClusterFactory.create(),
+            project_type=ProjectTypeFactory.create(),
+            sector=ProjectSectorFactory.create(),
+        )
+        ProjectOdsOdpFactory.create(project=project_with_ods)
+        project_without_ods = ProjectFactory.create(
+            submission_status=project_approved_status,
+            cluster=ProjectClusterFactory.create(),
+            project_type=ProjectTypeFactory.create(),
+            sector=ProjectSectorFactory.create(),
+        )
+        project_with_existing_obsolete_mapping = ProjectFactory.create(
+            submission_status=project_approved_status,
+            cluster=ProjectClusterFactory.create(),
+            project_type=ProjectTypeFactory.create(),
+            sector=ProjectSectorFactory.create(),
+        )
+        ProjectOdsOdpFactory.create(project=project_with_existing_obsolete_mapping)
+        existing_obsolete_mapping = ProjectSpecificFieldsFactory.create(
+            cluster=project_with_existing_obsolete_mapping.cluster,
+            type=project_with_existing_obsolete_mapping.project_type,
+            sector=project_with_existing_obsolete_mapping.sector,
+            obsolete=True,
+        )
+
+        project_specific_fields_obsolete.create_obsolete_project_specific_fields(
+            apps, None
+        )
+
+        obsolete_mapping = ProjectSpecificFields.objects.with_obsolete().get(
+            cluster=project_with_ods.cluster,
+            type=project_with_ods.project_type,
+            sector=project_with_ods.sector,
+        )
+        assert obsolete_mapping.obsolete is True
+        assert set(
+            obsolete_mapping.fields.values_list("write_field_name", flat=True)
+        ) == set(generic_field_names)
+        assert not ProjectSpecificFields.objects.filter(
+            cluster=project_without_ods.cluster,
+            type=project_without_ods.project_type,
+            sector=project_without_ods.sector,
+        ).exists()
+        assert not ProjectSpecificFields.objects.filter(
+            cluster=project_with_ods.cluster,
+            type=project_with_ods.project_type,
+            sector=project_with_ods.sector,
+        ).exists()
+        assert (
+            ProjectSpecificFields.objects.with_obsolete()
+            .filter(
+                cluster=project_with_existing_obsolete_mapping.cluster,
+                type=project_with_existing_obsolete_mapping.project_type,
+                sector=project_with_existing_obsolete_mapping.sector,
+            )
+            .count()
+            == 1
+        )
+        existing_obsolete_mapping.refresh_from_db()
+        assert not existing_obsolete_mapping.fields.exists()
 
 
 @pytest.fixture(name="_setup_rbm_measures")

--- a/core/api/tests/projects/test_projects_v2_export.py
+++ b/core/api/tests/projects/test_projects_v2_export.py
@@ -142,6 +142,33 @@ def ensure_substance_details_docx_fields(project: Project):
     project_specific_fields.fields.add(substance_field)
 
 
+def ensure_obsolete_substance_details_docx_fields(project: Project):
+    (
+        project_specific_fields,
+        _,
+    ) = ProjectSpecificFields.objects.with_obsolete().get_or_create(
+        cluster=project.cluster,
+        type=project.project_type,
+        sector=project.sector,
+        defaults={"obsolete": True},
+    )
+    for field_name, label, data_type in [
+        ("ods_display_name", "Substance", "text"),
+        ("ods_replacement_text", "Replacement technologies", "text"),
+        ("odp", "Phase-out (ODP tonnes)", "decimal"),
+    ]:
+        field = ProjectField.objects.create(
+            import_name=field_name,
+            label=label,
+            read_field_name=field_name,
+            write_field_name=field_name,
+            table="ods_odp",
+            data_type=data_type,
+            section="Substance Details",
+        )
+        project_specific_fields.fields.add(field)
+
+
 def validate_single_project_export(project: Project, response: FileResponse):
     assert response.filename == f"Project {project.id}.xlsx", response.filename
 
@@ -1013,6 +1040,31 @@ class TestProjectV2ExportDOCX(BaseTest):
             "FK baseline substance",
             "FK replacement substance",
         ] in substance_columns
+
+    def test_export_project_docx_uses_obsolete_specific_fields_for_ods_rows(
+        self, project_with_linked_bp, agency_inputter_user
+    ):
+        ensure_obsolete_substance_details_docx_fields(project_with_linked_bp)
+        project_ods_odp = project_with_linked_bp.ods_odp.first()
+        project_ods_odp.ods_display_name = "CFC-11"
+        project_ods_odp.ods_replacement_text = "Cyclopentane"
+        project_ods_odp.odp = 200
+        project_ods_odp.save()
+
+        self.client.force_authenticate(user=agency_inputter_user)
+        response: FileResponse = self.client.get(
+            self.url, {"project_id": project_with_linked_bp.id, "output_format": "docx"}
+        )
+
+        content = response.getvalue()
+        validate_docx_export(
+            project_with_linked_bp, agency_inputter_user, response, content
+        )
+        substance_rows = get_docx_table_rows(content, "Baseline substance")
+        assert any(
+            row[0] == "CFC-11" and row[1] == "Cyclopentane" and row[-1] == "200.00"
+            for row in substance_rows
+        )
 
     def test_export_project_mya_uses_computed_values_only_when_stored_value_missing(
         self,

--- a/core/api/views/projects.py
+++ b/core/api/views/projects.py
@@ -427,7 +427,13 @@ class ProjectSpecificFieldsListView(generics.RetrieveAPIView):
             else:
                 include_actuals = True
 
-        queryset = ProjectSpecificFields.objects.select_related(
+        project_specific_fields_manager = ProjectSpecificFields.objects
+        if project_id:
+            project_specific_fields_manager = (
+                ProjectSpecificFields.objects.with_obsolete()
+            )
+
+        queryset = project_specific_fields_manager.select_related(
             "cluster", "type", "sector"
         ).prefetch_related(
             models.Prefetch(

--- a/core/import_data_v2/scripts/import_cluster_type_sector_links.py
+++ b/core/import_data_v2/scripts/import_cluster_type_sector_links.py
@@ -53,8 +53,31 @@ def import_cluster_type_sector_links(file_path):
                         f"⚠️ {sector_name} sector not found => {cluster_json['cluster']} not imported"
                     )
                     continue
-                ProjectSpecificFields.objects.update_or_create(
-                    cluster=cluster,
-                    type=type_obj,
-                    sector=sector,
+                project_specific_fields = (
+                    ProjectSpecificFields.objects.with_obsolete()
+                    .filter(
+                        cluster=cluster,
+                        type=type_obj,
+                        sector=sector,
+                    )
+                    .first()
                 )
+                if project_specific_fields is None:
+                    ProjectSpecificFields.objects.create(
+                        cluster=cluster,
+                        type=type_obj,
+                        sector=sector,
+                    )
+                    continue
+
+                if project_specific_fields.obsolete:
+                    logger.warning(
+                        "Reactivating obsolete project-specific fields mapping "
+                        "from official cluster/type/sector import: "
+                        "%s / %s / %s",
+                        cluster.name,
+                        type_obj.name,
+                        sector.name,
+                    )
+                    project_specific_fields.obsolete = False
+                    project_specific_fields.save(update_fields=["obsolete"])

--- a/core/migrations/0305_projectspecificfields_obsolete.py
+++ b/core/migrations/0305_projectspecificfields_obsolete.py
@@ -1,0 +1,95 @@
+import core.models.project_metadata
+from django.db import migrations, models
+from django.db.models import Count, Exists, OuterRef
+
+
+GENERIC_SUBSTANCE_FIELD_NAMES = [
+    "ods_display_name",
+    "ods_replacement_text",
+    "odp",
+    "phase_out_mt",
+    "co2_mt",
+    "products_manufactured",
+]
+
+
+def create_obsolete_project_specific_fields(apps, _schema_editor):
+    Project = apps.get_model("core", "Project")
+    ProjectField = apps.get_model("core", "ProjectField")
+    ProjectSpecificFields = apps.get_model("core", "ProjectSpecificFields")
+
+    generic_fields = list(
+        ProjectField.objects.filter(
+            write_field_name__in=GENERIC_SUBSTANCE_FIELD_NAMES,
+        )
+    )
+
+    missing_combinations = (
+        Project.objects.filter(
+            latest_project__isnull=True,
+            submission_status__name="Approved",
+            ods_odp__isnull=False,
+        )
+        .exclude(cluster__isnull=True)
+        .exclude(project_type__isnull=True)
+        .exclude(sector__isnull=True)
+        .annotate(
+            has_project_specific_fields=Exists(
+                ProjectSpecificFields.objects.with_obsolete().filter(
+                    cluster_id=OuterRef("cluster_id"),
+                    type_id=OuterRef("project_type_id"),
+                    sector_id=OuterRef("sector_id"),
+                )
+            )
+        )
+        .filter(has_project_specific_fields=False)
+        .values("cluster_id", "project_type_id", "sector_id")
+        .annotate(project_count=Count("id", distinct=True))
+    )
+
+    for combination in missing_combinations:
+        (
+            project_specific_fields,
+            _created,
+        ) = ProjectSpecificFields.objects.with_obsolete().get_or_create(
+            cluster_id=combination["cluster_id"],
+            type_id=combination["project_type_id"],
+            sector_id=combination["sector_id"],
+            defaults={"obsolete": True},
+        )
+        if not project_specific_fields.obsolete:
+            project_specific_fields.obsolete = True
+            project_specific_fields.save(update_fields=["obsolete"])
+        project_specific_fields.fields.set(generic_fields)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0304_alter_decision_options_alter_meeting_options"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="projectspecificfields",
+            name="obsolete",
+            field=models.BooleanField(
+                default=False,
+                help_text=(
+                    "If True, this mapping is only used for rendering legacy project data."
+                ),
+            ),
+        ),
+        migrations.AlterModelManagers(
+            name="projectspecificfields",
+            managers=[
+                (
+                    "objects",
+                    core.models.project_metadata.ProjectSpecificFieldsManager(),
+                ),
+            ],
+        ),
+        migrations.RunPython(
+            create_obsolete_project_specific_fields,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/core/models/project_metadata.py
+++ b/core/models/project_metadata.py
@@ -104,6 +104,27 @@ class ProjectField(models.Model):
         )
 
 
+class ProjectSpecificFieldsQuerySet(models.QuerySet):
+    """
+    Queryset for project-specific field mappings.
+    """
+
+    def active(self):
+        return self.filter(obsolete=False)
+
+
+class ProjectSpecificFieldsManager(
+    models.Manager.from_queryset(ProjectSpecificFieldsQuerySet)
+):
+    use_in_migrations = True
+
+    def get_queryset(self):
+        return super().get_queryset().active()
+
+    def with_obsolete(self):
+        return super().get_queryset()
+
+
 class ProjectSpecificFields(models.Model):
     """
     Model that for a combination of cluster, type and sector
@@ -132,6 +153,12 @@ class ProjectSpecificFields(models.Model):
         help_text="List of fields that should be filled in the project for this"
         " combination of cluster, type and sector",
     )
+    obsolete = models.BooleanField(
+        default=False,
+        help_text="If True, this mapping is only used for rendering legacy project data.",
+    )
+
+    objects = ProjectSpecificFieldsManager()
 
     class Meta:
         verbose_name_plural = "Project specific fields"


### PR DESCRIPTION
- Migration: NEW `ProjectSpecificFields.obsolete` (default=False) field.
- Migration: Find Projects with `ods_odp` but no `ProjectSpecificFields`, add a new `ProjectSpecificFields` entry with required fields to render `ods_odp` data (view and exports).
- Add `ProjectSpecificFieldsManager` so that `ProjectSpecificFields.objects` defaults to `obsolete=False`
- Update `import_cluster_type_sector_links.py` script so that existing `ProjectSpecificFields.obsolete=True` will be set as `obsolete=False` (activated) as part of the import script. This should not usually happen as the current implementation fixes **MISSING** `ProjectSpecificFields`.