### PR TITLE
Fixing APR save 403s caused by missing CSRF cookie

### DIFF
--- a/core/api/tests/test_csrf_cookie_middleware.py
+++ b/core/api/tests/test_csrf_cookie_middleware.py
@@ -1,0 +1,60 @@
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from core.models import AnnualAgencyProjectReport
+
+
+@pytest.mark.django_db
+class TestEnsureCsrfCookieMiddleware:
+    """Regression test: a session cookie without a matching csrftoken cookie
+    used to 403 APR writes with "CSRF cookie not set"."""
+
+    def test_authenticated_get_issues_missing_csrf_cookie(self, mlfs_admin_user):
+        client = APIClient(enforce_csrf_checks=True)
+        client.force_login(mlfs_admin_user)
+        assert "csrftoken" not in client.cookies
+
+        response = client.get(reverse("apr-current-year"))
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "csrftoken" in response.cookies
+
+    def test_post_self_heals_after_an_authenticated_get(
+        self, mlfs_admin_user, annual_agency_report
+    ):
+        annual_agency_report.status = (
+            AnnualAgencyProjectReport.SubmissionStatus.SUBMITTED
+        )
+        annual_agency_report.is_unlocked = False
+        annual_agency_report.save()
+
+        client = APIClient(enforce_csrf_checks=True)
+        client.force_login(mlfs_admin_user)
+
+        url = reverse(
+            "apr-toggle-lock",
+            kwargs={
+                "year": annual_agency_report.progress_report.year,
+                "agency_id": annual_agency_report.agency.id,
+            },
+        )
+
+        # session with no csrftoken cookie yet -> write is rejected
+        response = client.post(url, {"is_unlocked": True}, format="json")
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "CSRF" in response.data["detail"]
+
+        # any authenticated GET self-heals the missing cookie
+        client.get(reverse("apr-current-year"))
+        csrf_token = client.cookies["csrftoken"].value
+
+        response = client.post(
+            url,
+            {"is_unlocked": True},
+            format="json",
+            HTTP_X_CSRFTOKEN=csrf_token,
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["is_unlocked"] is True

--- a/core/middleware.py
+++ b/core/middleware.py
@@ -1,0 +1,18 @@
+from django.middleware.csrf import get_token
+
+
+class EnsureCsrfCookieMiddleware:
+    """
+    Re-issues the csrftoken cookie on every authenticated response, so a
+    session cookie can never end up without a matching CSRF cookie (which
+    causes DRF's SessionAuthentication to reject writes with "CSRF cookie
+    not set" even for a properly authenticated user).
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if getattr(request, "user", None) and request.user.is_authenticated:
+            get_token(request)
+        return self.get_response(request)

--- a/multilateralfund/settings.py
+++ b/multilateralfund/settings.py
@@ -102,6 +102,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "core.middleware.EnsureCsrfCookieMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]


### PR DESCRIPTION
Entra-ID-logged-in MLFS was getting `403 CSRF Failed: CSRF cookie not set` when saving or locking/unlocking APR 2024 reports, even though they were properly logged in. Reads worked fine — only writes (bulk-update, toggle-lock) failed.

**Root cause**: a browser can end up with a valid Django session cookie but no matching csrftoken cookie (the CSRF cookie is normally only issued once, at login). Since `SessionAuthentication` is checked first in DRF's auth chain, any request authenticated via that session gets CSRF-enforced - with no cookie to check against, it's rejected outright, regardless of how the user actually authenticated.