### PR TITLE
[refs #37548] Generate JWT tokens Entra ID login

### DIFF
--- a/core/api/views/auth.py
+++ b/core/api/views/auth.py
@@ -1,8 +1,16 @@
+#pylint: disable=ungrouped-imports
+
 from datetime import datetime, timedelta, timezone
 
 from dj_rest_auth.views import LoginView
 from django.conf import settings
+
+from django_auth_adfs.rest_framework import AdfsAccessTokenAuthentication
+from rest_framework import permissions, status
+from rest_framework.response import Response
 from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework.views import APIView
+
 
 
 class CustomLoginView(LoginView):
@@ -44,5 +52,54 @@ class CustomLoginView(LoginView):
                     httponly=True,
                     samesite="Lax",
                 )
+
+        return response
+
+
+class ADFSLoginView(APIView):
+    permission_classes = [permissions.AllowAny]
+    authentication_classes = []
+
+    def post(self, request, *args, **kwargs):
+        auth_header = request.META.get("HTTP_AUTHORIZATION", "")
+        if not auth_header.startswith("Bearer "):
+            return Response(
+                {"detail": "Bearer token required for ADFS login."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        result = AdfsAccessTokenAuthentication().authenticate(request)
+        if result is None:
+            return Response(
+                {"detail": "Invalid ADFS access token."},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        user, _ = result
+        refresh = RefreshToken.for_user(user)
+        access = str(refresh.access_token)
+
+        response = Response(
+            {"access": access, "refresh": str(refresh)},
+            status=status.HTTP_200_OK,
+        )
+
+        cookie_opts = {
+            "httponly": False,
+            "secure": settings.SESSION_COOKIE_SECURE,
+            "samesite": "Lax",
+            "path": "/",
+        }
+
+        response.set_cookie(
+            settings.REST_AUTH["JWT_AUTH_COOKIE"],
+            access,
+            **cookie_opts,
+        )
+        response.set_cookie(
+            settings.REST_AUTH["JWT_AUTH_REFRESH_COOKIE"],
+            str(refresh),
+            **cookie_opts,
+        )
 
         return response

--- a/core/api/views/auth.py
+++ b/core/api/views/auth.py
@@ -1,4 +1,4 @@
-#pylint: disable=ungrouped-imports
+# pylint: disable=ungrouped-imports
 
 from datetime import datetime, timedelta, timezone
 
@@ -10,7 +10,6 @@ from rest_framework import permissions, status
 from rest_framework.response import Response
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework.views import APIView
-
 
 
 class CustomLoginView(LoginView):

--- a/core/auth.py
+++ b/core/auth.py
@@ -1,3 +1,4 @@
+import jwt
 import logging
 
 from django_auth_adfs.rest_framework import AdfsAccessTokenAuthentication
@@ -18,9 +19,24 @@ class SmartTokenAuthentication(BaseAuthentication):
     Falls back to the other backend if the preferred one fails.
     """
 
-    def _is_adfs_token(self, claims: dict) -> bool:
+    def _get_token(self, request):
+        auth_header = request.META.get("HTTP_AUTHORIZATION", "")
+        if auth_header.startswith("Bearer "):
+            return auth_header.split(" ", 1)[1]
+
+        jwt_cookie_name = getattr(settings, "REST_AUTH", {}).get("JWT_AUTH_COOKIE")
+        if jwt_cookie_name:
+            return request.COOKIES.get(jwt_cookie_name)
+
+        return None
+
+    def _is_adfs_token(self, token: dict) -> bool:
+        try:
+            claims = jwt.decode(token, options={"verify_signature": False})
+        except Exception:
+            return False
+
         iss = (claims.get("iss") or "").lower()
-        aud = claims.get("aud")
         # common MS issuers
         if any(
             x in iss
@@ -33,26 +49,27 @@ class SmartTokenAuthentication(BaseAuthentication):
         if configured_aud:
             if not isinstance(configured_aud, (list, tuple)):
                 configured_aud = [configured_aud]
+            aud = claims.get("aud")
             aud_values = aud if isinstance(aud, (list, tuple)) else [aud] if aud else []
-            if any(a in configured_aud for a in aud_values):
+            if any(a in configured_aud for a in aud_values if a):
                 return True
         return False
 
     def authenticate(self, request):
-        auth_header = request.META.get("HTTP_AUTHORIZATION", "")
-        if not auth_header.startswith("Bearer "):
+        token = self._get_token(request)
+        if not token:
             return None
 
-        # try ADFS first
-        try:
-            return AdfsAccessTokenAuthentication().authenticate(request)
-        except AuthenticationFailed:
-            pass
+        if self._is_adfs_token(token):
+            try:
+                return AdfsAccessTokenAuthentication().authenticate(request)
+            except AuthenticationFailed:
+                pass
 
-        # then JWT
-        try:
-            return JWTAuthentication().authenticate(request)
-        except AuthenticationFailed:
-            pass
+        # If token came from cookie, expose it as Authorization for JWTAuthentication
+        if "HTTP_AUTHORIZATION" not in request.META or not request.META[
+            "HTTP_AUTHORIZATION"
+        ].startswith("Bearer "):
+            request.META["HTTP_AUTHORIZATION"] = f"Bearer {token}"
 
-        return None
+        return JWTAuthentication().authenticate(request)

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -29,6 +29,10 @@ import { ProjectSubSectorType } from '@ors/types/api_project_subsector.ts'
 import { ProjectSubmissionStatusType } from '@ors/types/api_project_submission_statuses.ts'
 import { ProjectSubstancesGroupsType } from '@ors/types/api_project_substances_groups'
 
+import { scopes } from '@ors/config/msalConfig'
+import { useMsal } from '@azure/msal-react'
+import Cookies from 'js-cookie'
+
 async function fetchAppBootstrapData() {
   const [
     // Common data
@@ -201,6 +205,7 @@ function ClientAppGate({ children }: { children: React.ReactNode }) {
   const user = useStore((state) => state.user)
   const getUser = useStore((state) => state.user.getUser)
   const appBootstrapped = useAppBootstrap(user.data?.pk)
+  const { instance } = useMsal()
 
   const currentView = getCurrentView(pathname || '')
   const isLoginPath = pathname === '/login'
@@ -254,6 +259,28 @@ function ClientAppGate({ children }: { children: React.ReactNode }) {
     },
     [appBootstrapped, isLoginPath, isProtectedPath, user.data, user.loaded],
   )
+
+  useEffect(() => {
+    const initializeUser = async () => {
+      const authToken = Cookies.get('orsauth')
+
+      if (!authToken) {
+        const account =
+          instance.getActiveAccount() || instance.getAllAccounts()[0]
+
+        if (account) {
+          const token = await instance.acquireTokenSilent({ account, scopes })
+
+          await api('/api/auth/adfs-login/', {
+            headers: { Authorization: `Bearer ${token.accessToken}` },
+            method: 'POST',
+          })
+        }
+      }
+    }
+
+    initializeUser().catch(console.error)
+  }, [instance])
 
   return <View>{shouldRenderView ? children : null}</View>
 }

--- a/frontend/src/slices/createUserSlice.ts
+++ b/frontend/src/slices/createUserSlice.ts
@@ -73,7 +73,6 @@ export const createUserSlice = ({
       await api('api/auth/logout/', {
         method: 'post',
       })
-      removeCookies()
 
       const hasMsalSession = msalInstance.getAllAccounts().length > 0
 
@@ -82,6 +81,8 @@ export const createUserSlice = ({
           postLogoutRedirectUri: window.location.origin,
         })
       }
+
+      removeCookies()
 
       setSlice('user', {
         data: null,

--- a/multilateralfund/urls.py
+++ b/multilateralfund/urls.py
@@ -25,7 +25,7 @@ from dj_rest_auth.views import (
     PasswordResetView,
     PasswordResetConfirmView,
 )
-from core.api.views import CustomLoginView
+from core.api.views import ADFSLoginView, CustomLoginView
 from core.api.views.users import AuthDebugView
 
 # from api import urls as apis_urls
@@ -42,6 +42,7 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     # Overriding the dj_rest_auth token view to return long-lived tokens if needed
     path("api/auth/login/", CustomLoginView.as_view(), name="rest_login"),
+    path("api/auth/adfs-login/", ADFSLoginView.as_view(), name="adfs_login"),
     path("api/auth/", include("dj_rest_auth.urls")),
     path(
         "api/auth/password_reset/", PasswordResetView.as_view(), name="password_reset"


### PR DESCRIPTION
Implements an exchange endpoint so frontend can authenticate via ADFS/Entra and receive the same local JWT cookies (orsauth, orsrefresh) used by the app’s other auth flows.

**New view**: ADFSLoginView (POST /api/auth/adfs-login/) — accepts Authorization: Bearer <adfs_token>, validates it, issues refresh & access tokens and sets orsauth/orsrefresh cookies.

Updated the `core.auth.SmartTokenAuthentication` to:
* read token from Authorization header or JWT cookie
* detect ADFS tokens by inspecting claims
* delegate to AdfsAccessTokenAuthentication when appropriate
* otherwise use JWTAuthentication (with cookie support)
