### PR TITLE
Fix funding window decision rendering on dashboard export

### DIFF
--- a/core/api/export/projects_dashboard_dump.py
+++ b/core/api/export/projects_dashboard_dump.py
@@ -128,14 +128,6 @@ def get_subregion(p, _):
     return ""
 
 
-def get_funding_window(p, _):
-    # The base dump str()s the FK ("FundingWindow object (5)"). Render the
-    # decision code instead, e.g. "91/65", as the inventory report does.
-    if not p.funding_window:
-        return ""
-    return getattr(p.funding_window.decision, "number", "") or ""
-
-
 def get_type_simple(p, _):
     if p.project_type and p.project_type.code == "INV":
         return "Investment"
@@ -249,9 +241,6 @@ class ProjectsDashboardDumpWriter(ProjectsV2DumpWriter):
 
     def _build_headers(self, fields, source=None):
         result = super()._build_headers(fields, source)
-        for header in result:
-            if header["id"] == "funding_window":
-                header["method"] = get_funding_window
         return [h for h in result if h["id"] not in ("actual_total_fund", "actual_psc")]
 
 

--- a/core/api/export/projects_dashboard_dump.py
+++ b/core/api/export/projects_dashboard_dump.py
@@ -128,6 +128,14 @@ def get_subregion(p, _):
     return ""
 
 
+def get_funding_window(p, _):
+    # The base dump str()s the FK ("FundingWindow object (5)"). Render the
+    # decision code instead, e.g. "91/65", as the inventory report does.
+    if not p.funding_window:
+        return ""
+    return getattr(p.funding_window.decision, "number", "") or ""
+
+
 def get_type_simple(p, _):
     if p.project_type and p.project_type.code == "INV":
         return "Investment"
@@ -241,6 +249,9 @@ class ProjectsDashboardDumpWriter(ProjectsV2DumpWriter):
 
     def _build_headers(self, fields, source=None):
         result = super()._build_headers(fields, source)
+        for header in result:
+            if header["id"] == "funding_window":
+                header["method"] = get_funding_window
         return [h for h in result if h["id"] not in ("actual_total_fund", "actual_psc")]
 
 
@@ -286,8 +297,11 @@ class ProjectsDashboardDump(ProjectsV2Dump):
             if t.strip()
         }
         # Extend the parent queryset with the geo traversal needed for
-        # country_iso, Region, and Sub-Region columns.
-        self.queryset = self.queryset.select_related("country__parent__parent")
+        # country_iso, Region, and Sub-Region columns, and the decision behind
+        # the funding window column.
+        self.queryset = self.queryset.select_related(
+            "country__parent__parent", "funding_window__decision"
+        )
 
     def _apply_filters(self, projects):
         if self.latest_only:

--- a/core/api/export/projects_v2_dump.py
+++ b/core/api/export/projects_v2_dump.py
@@ -474,7 +474,10 @@ class ProjectsV2Dump:
         )
         queryset = (
             Project.objects.really_all()
-            .select_related(*self.get_fk_fields(self.project_fields))
+            .select_related(
+                *self.get_fk_fields(self.project_fields),
+                "funding_window__decision",
+            )
             .prefetch_related(
                 *self.get_m2m_fields(self.project_fields),
                 "component__projects",

--- a/core/api/tests/projects/test_projects_dashboard_export.py
+++ b/core/api/tests/projects/test_projects_dashboard_export.py
@@ -12,6 +12,7 @@ from openpyxl.utils import get_column_letter
 from core.api.tests.base import BaseTest
 from core.api.tests.factories import (
     CountryFactory,
+    FundingWindowFactory,
     MetaProjectFactory,
     ProjectFactory,
     ProjectTypeFactory,
@@ -41,6 +42,11 @@ def get_project_row(sheet, project_id):
         ),
         None,
     )
+
+
+def funding_window_column(headers):
+    # Labelled from ProjectField when that table is populated, else the field name.
+    return headers.get("Funding window") or headers["funding_window"]
 
 
 def load_projects_sheet(response):
@@ -592,6 +598,37 @@ class TestProjectsDashboardExport(BaseTest):
         row = get_project_row(sheet, approved_project.id)
         assert row is not None, "Project not found in export"
         assert sheet[f"{headers['Type Simple']}{row}"].value == "Non-Investment"
+
+    # Funding window
+    def test_funding_window_shows_decision_number(
+        self, secretariat_viewer_user, approved_project
+    ):
+        approved_project.funding_window = FundingWindowFactory.create(
+            decision__number="91/65"
+        )
+        approved_project.save()
+        self.client.force_authenticate(user=secretariat_viewer_user)
+        response = self.client.get(
+            self.url, {"latest_only": "false", "mock_data": "false"}
+        )
+        sheet = load_projects_sheet(response)
+        headers = get_sheet_headers(sheet)
+        row = get_project_row(sheet, approved_project.id)
+        assert row is not None, "Project not found in export"
+        assert sheet[f"{funding_window_column(headers)}{row}"].value == "91/65"
+
+    def test_funding_window_empty_when_unset(
+        self, secretariat_viewer_user, approved_project
+    ):
+        self.client.force_authenticate(user=secretariat_viewer_user)
+        response = self.client.get(
+            self.url, {"latest_only": "false", "mock_data": "false"}
+        )
+        sheet = load_projects_sheet(response)
+        headers = get_sheet_headers(sheet)
+        row = get_project_row(sheet, approved_project.id)
+        assert row is not None, "Project not found in export"
+        assert sheet[f"{funding_window_column(headers)}{row}"].value is None
 
     # Substances sheet
     def test_substances_sheet_includes_ods_odp_rows(

--- a/core/models/funding_window.py
+++ b/core/models/funding_window.py
@@ -30,3 +30,7 @@ class FundingWindow(models.Model):
         help_text="Funding Window Amount (US$)",
     )
     remarks = models.TextField(null=True, blank=True, help_text="Remarks")
+
+    def __str__(self):
+        # A funding window is identified by its decision code, e.g. "91/65".
+        return (self.decision.number if self.decision else "") or ""

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,5 +13,5 @@ pylint-django==2.6.1
 pylint-secure-coding-standard==1.5.1
 pytest
 pytest-cov
-pytest-django
+pytest-django<4.13  # 4.13 dropped Django 4.2, but doesn't say so in its metadata
 pytest-subtests


### PR DESCRIPTION
Fix the Funding window column in `GET /api/projects/v2/dashboards/all/`, which rendered e.g. "FundingWindow object (5)" instead of the decision code. The dashboard writer now renders `decision.number` (e.g. "91/65"), matching the inventory report and the funding-window UI, and adds accompanying tests.

A more durable/general fix could be to modify the `FundingWindow` model itself to produce this, as it has no `__str__` method or `.name` defined, but I was unsure if this is the way we'd always want to represent a Funding Window in the `projects/v2/export` endpoint, Django admin, etc.

Please let me know if you'd rather we made that change or have any other questions!